### PR TITLE
Switch from letsencrypt-win lib submodule to ACMESharp nuget and latest API

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "letsencrypt-win"]
-	path = letsencrypt-win
-	url = https://github.com/ebekker/letsencrypt-win.git

--- a/letsencrypt-win-simple.sln
+++ b/letsencrypt-win-simple.sln
@@ -3,42 +3,24 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LetsEncrypt.ACME", "letsencrypt-win\letsencrypt-win\LetsEncrypt.ACME\LetsEncrypt.ACME.csproj", "{D551234B-0A8D-4DEE-8178-A81998DF0EDB}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LetsEncrypt.ACME-test", "letsencrypt-win\letsencrypt-win\LetsEncrypt.ACME-test\LetsEncrypt.ACME-test.csproj", "{6D7BE73B-B9E7-431A-93AA-C4956B7827C3}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "shared", "shared", "{2D8381C9-5B29-400B-B86C-4669876052DB}"
-	ProjectSection(SolutionItems) = preProject
-		shared\SharedAssemblyInfo.cs = shared\SharedAssemblyInfo.cs
-		shared\SharedAssemblyVersionInfo.cs = shared\SharedAssemblyVersionInfo.cs
-	EndProjectSection
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LetsEncrypt.ACME.POSH", "letsencrypt-win\letsencrypt-win\LetsEncrypt.ACME.POSH\LetsEncrypt.ACME.POSH.csproj", "{2F8D5934-B5A7-4983-8051-1F25882C7C30}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "letsencrypt-win-simple", "letsencrypt-win-simple\letsencrypt-win-simple.csproj", "{30CC3DE8-AA52-4807-9B0D-EBA08B539918}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{D551234B-0A8D-4DEE-8178-A81998DF0EDB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{D551234B-0A8D-4DEE-8178-A81998DF0EDB}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D551234B-0A8D-4DEE-8178-A81998DF0EDB}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{D551234B-0A8D-4DEE-8178-A81998DF0EDB}.Release|Any CPU.Build.0 = Release|Any CPU
-		{6D7BE73B-B9E7-431A-93AA-C4956B7827C3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6D7BE73B-B9E7-431A-93AA-C4956B7827C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6D7BE73B-B9E7-431A-93AA-C4956B7827C3}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6D7BE73B-B9E7-431A-93AA-C4956B7827C3}.Release|Any CPU.Build.0 = Release|Any CPU
-		{2F8D5934-B5A7-4983-8051-1F25882C7C30}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{2F8D5934-B5A7-4983-8051-1F25882C7C30}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2F8D5934-B5A7-4983-8051-1F25882C7C30}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{2F8D5934-B5A7-4983-8051-1F25882C7C30}.Release|Any CPU.Build.0 = Release|Any CPU
 		{30CC3DE8-AA52-4807-9B0D-EBA08B539918}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{30CC3DE8-AA52-4807-9B0D-EBA08B539918}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{30CC3DE8-AA52-4807-9B0D-EBA08B539918}.Debug|x86.ActiveCfg = Debug|x86
+		{30CC3DE8-AA52-4807-9B0D-EBA08B539918}.Debug|x86.Build.0 = Debug|x86
 		{30CC3DE8-AA52-4807-9B0D-EBA08B539918}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{30CC3DE8-AA52-4807-9B0D-EBA08B539918}.Release|Any CPU.Build.0 = Release|Any CPU
+		{30CC3DE8-AA52-4807-9B0D-EBA08B539918}.Release|x86.ActiveCfg = Release|x86
+		{30CC3DE8-AA52-4807-9B0D-EBA08B539918}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/letsencrypt-win-simple/letsencrypt-win-simple.csproj
+++ b/letsencrypt-win-simple/letsencrypt-win-simple.csproj
@@ -34,12 +34,67 @@
   <PropertyGroup>
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
   <ItemGroup>
+    <Reference Include="ACMESharp, Version=0.7.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ACMESharp.0.7.0.109-EA\lib\net45\ACMESharp.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ACMESharp.PKI.Providers.OpenSslLib32, Version=0.7.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ACMESharp.PKI.Providers.OpenSslLib32.0.7.0.109-EA\lib\net45\ACMESharp.PKI.Providers.OpenSslLib32.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ACMESharp.PKI.Providers.OpenSslLib64, Version=0.7.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ACMESharp.PKI.Providers.OpenSslLib64.0.7.0.109-EA\lib\net45\ACMESharp.PKI.Providers.OpenSslLib64.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="AWSSDK.Core, Version=3.1.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
+      <HintPath>..\packages\AWSSDK.Core.3.1.1.0\lib\net45\AWSSDK.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="AWSSDK.Route53, Version=3.1.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
+      <HintPath>..\packages\AWSSDK.Route53.3.1.0.1\lib\net45\AWSSDK.Route53.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="AWSSDK.S3, Version=3.1.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
+      <HintPath>..\packages\AWSSDK.S3.3.1.2.1\lib\net45\AWSSDK.S3.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="CommandLine, Version=2.0.275.0, Culture=neutral, PublicKeyToken=de6f01bd326f8c32, processorArchitecture=MSIL">
       <HintPath>..\packages\CommandLineParser.2.0.275-beta\lib\net45\CommandLine.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ManagedOpenSsl, Version=0.6.1.0, Culture=neutral, PublicKeyToken=null" />
+    <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ManagedOpenSsl, Version=0.6.1.0, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\packages\ManagedOpenSsl32.0.6.1.1\lib\net20\ManagedOpenSsl.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ManagedOpenSsl64, Version=0.6.1.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\ManagedOpenSsl64.0.6.1.1\lib\net20\ManagedOpenSsl64.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.Web.Administration, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Web.Administration.7.0.0.0\lib\net20\Microsoft.Web.Administration.dll</HintPath>
       <Private>True</Private>
@@ -80,10 +135,22 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\letsencrypt-win\letsencrypt-win\LetsEncrypt.ACME\LetsEncrypt.ACME.csproj">
-      <Project>{d551234b-0a8d-4dee-8178-a81998df0edb}</Project>
-      <Name>LetsEncrypt.ACME</Name>
-    </ProjectReference>
+    <Content Include="..\packages\ManagedOpenSsl32.0.6.1.1\content\x86\libeay32.dll">
+      <Link>x86\libeay32.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\packages\ManagedOpenSsl32.0.6.1.1\content\x86\ssleay32.dll">
+      <Link>x86\ssleay32.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\packages\ManagedOpenSsl64.0.6.1.1\content\x64\libeay32.dll">
+      <Link>x64\libeay32.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\packages\ManagedOpenSsl64.0.6.1.1\content\x64\ssleay32.dll">
+      <Link>x64\ssleay32.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/letsencrypt-win-simple/packages.config
+++ b/letsencrypt-win-simple/packages.config
@@ -1,6 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="ACMESharp" version="0.7.0.109-EA" targetFramework="net45" />
+  <package id="ACMESharp.PKI.Providers.OpenSslLib32" version="0.7.0.109-EA" targetFramework="net45" />
+  <package id="ACMESharp.PKI.Providers.OpenSslLib64" version="0.7.0.109-EA" targetFramework="net45" />
+  <package id="AWSSDK.Core" version="3.1.1.0" targetFramework="net45" />
+  <package id="AWSSDK.Route53" version="3.1.0.1" targetFramework="net45" />
+  <package id="AWSSDK.S3" version="3.1.2.1" targetFramework="net45" />
   <package id="CommandLineParser" version="2.0.275-beta" targetFramework="net45" />
+  <package id="log4net" version="2.0.3" targetFramework="net45" />
+  <package id="ManagedOpenSsl32" version="0.6.1.1" targetFramework="net45" />
+  <package id="ManagedOpenSsl64" version="0.6.1.1" targetFramework="net45" />
   <package id="Microsoft.Web.Administration" version="7.0.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="TaskScheduler" version="2.5.3" targetFramework="net45" />


### PR DESCRIPTION
* Removed the letsencrypt-win git submodule
* Added references to latest ACMESharp (and related) nuget packages
* Updated code to use latest ACMESharp namespaces and new CertProvider interface instead of deprecated CsrHelper
* Includes support for auto-swiitching between 32/64-bit cert provider
