### PR TITLE
Increase authorization sleep

### DIFF
--- a/letsencrypt-win-simple/Program.cs
+++ b/letsencrypt-win-simple/Program.cs
@@ -530,7 +530,7 @@ namespace LetsEncrypt.ACME.Simple
                 while (authzState.Status == "pending")
                 {
                     Console.WriteLine(" Refreshing authorization");
-                    Thread.Sleep(1000); // this has to be here to give ACME server a chance to think
+                    Thread.Sleep(4000); // this has to be here to give ACME server a chance to think
                     var newAuthzState = client.RefreshIdentifierAuthorization(authzState);
                     if (newAuthzState.Status != "pending")
                         authzState = newAuthzState;


### PR DESCRIPTION
The .net cms-system that I running take > 5 seconds on initial startup that will make the authorization fail (if not the cms-system is removed from the wwwroot). Increasing the auth sleep timer will make the authorization to work but for fast system the delay will be some extra seconds.