### PR TITLE
Non Test Not Creating IIS Binding

### DIFF
--- a/letsencrypt-win-simple/Program.cs
+++ b/letsencrypt-win-simple/Program.cs
@@ -265,6 +265,10 @@ namespace LetsEncrypt.ACME.Simple
 
                         binding.Plugin.Install(binding, pfxFilename, store, certificate);
                     }
+                    else if(!Options.Renew)
+                    {
+                        binding.Plugin.Install(binding, pfxFilename, store, certificate);
+                    }
                 }
                 else if (!Options.Renew)
                 {


### PR DESCRIPTION
If you didn't use the test parameter, it wouldn't add the IIS binding, so I fixed that.