### PR TITLE
PFX Password & RSA Num Bits Support

### DIFF
--- a/letsencrypt-win-simple/App.config
+++ b/letsencrypt-win-simple/App.config
@@ -8,7 +8,7 @@
   <appSettings>
     <add key="serilog:minimum-level" value="Warning" />
     <add key="serilog:using" value="Serilog.Sinks.EventLog" />
-    <add key="serilog:write-to:EventLog.source" value="letsencrypt-win-simple" />
+    <add key="serilog:write-to:EventLog.source" value="letsencrypt_win_simple" />
   </appSettings>
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
@@ -17,6 +17,12 @@
     <LetsEncrypt.ACME.Simple.Properties.Settings>
       <setting name="FileDateFormat" serializeAs="String">
         <value>yyyy/M/d/ h:m:s tt</value>
+      </setting>
+      <setting name="PFXPassword" serializeAs="String">
+        <value></value>
+      </setting>
+      <setting name="RSAKeyBits" serializeAs="String">
+        <value>2048</value>
       </setting>
     </LetsEncrypt.ACME.Simple.Properties.Settings>
   </applicationSettings>

--- a/letsencrypt-win-simple/Properties/Settings.Designer.cs
+++ b/letsencrypt-win-simple/Properties/Settings.Designer.cs
@@ -31,5 +31,23 @@ namespace LetsEncrypt.ACME.Simple.Properties {
                 return ((string)(this["FileDateFormat"]));
             }
         }
+        
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string PFXPassword {
+            get {
+                return ((string)(this["PFXPassword"]));
+            }
+        }
+        
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("2048")]
+        public int RSAKeyBits {
+            get {
+                return ((int)(this["RSAKeyBits"]));
+            }
+        }
     }
 }

--- a/letsencrypt-win-simple/Properties/Settings.settings
+++ b/letsencrypt-win-simple/Properties/Settings.settings
@@ -5,5 +5,11 @@
     <Setting Name="FileDateFormat" Type="System.String" Scope="Application">
       <Value Profile="(Default)">yyyy/M/d/ h:m:s tt</Value>
     </Setting>
+    <Setting Name="PFXPassword" Type="System.String" Scope="Application">
+      <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="RSAKeyBits" Type="System.Int32" Scope="Application">
+      <Value Profile="(Default)">2048</Value>
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
Enabling a password for the pfx file.
Enabling support for specifying the number of bits for the RSA key (once
ACMESharp supports it).