### PR TITLE
Manage number of hosts

### DIFF
--- a/letsencrypt-win-simple/App.config
+++ b/letsencrypt-win-simple/App.config
@@ -19,10 +19,13 @@
         <value>yyyy/M/d/ h:m:s tt</value>
       </setting>
       <setting name="PFXPassword" serializeAs="String">
-        <value></value>
+        <value />
       </setting>
       <setting name="RSAKeyBits" serializeAs="String">
         <value>2048</value>
+      </setting>
+      <setting name="HostsPerPage" serializeAs="String">
+        <value>50</value>
       </setting>
     </LetsEncrypt.ACME.Simple.Properties.Settings>
   </applicationSettings>

--- a/letsencrypt-win-simple/Options.cs
+++ b/letsencrypt-win-simple/Options.cs
@@ -30,6 +30,9 @@ namespace LetsEncrypt.ACME.Simple
         [Option(HelpText = "Path for Centralized Certificate Store (This enables Centralized SSL). Ex. \\\\storage\\central_ssl\\")]
         public string CentralSSLStore { get; set; }
 
+        [Option(HelpText = "Hide sites that have existing HTTPS bindings")]
+        public bool HideHTTPS { get; set; }
+
         // can't easily make this a command line option since it would have to be saved
         //[Option(Default = 60f, HelpText = "Renewal period in days. Can be set to negative to test.")]
         //public float RenewalPeriod { get; set; } = 60;

--- a/letsencrypt-win-simple/Plugin/IISPlugin.cs
+++ b/letsencrypt-win-simple/Plugin/IISPlugin.cs
@@ -8,6 +8,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading.Tasks;
 using Serilog;
+using System.Text.RegularExpressions;
 
 namespace LetsEncrypt.ACME.Simple
 {
@@ -42,11 +43,13 @@ namespace LetsEncrypt.ACME.Simple
 
                         foreach (var binding in site.Bindings)
                         {
-                            if (!String.IsNullOrEmpty(binding.Host) && binding.Protocol == "http")
+                            //Get HTTP sites that aren't IDN
+                            if (!String.IsNullOrEmpty(binding.Host) && binding.Protocol == "http" && !Regex.IsMatch(binding.Host, @"[^\u0000-\u007F]"))
                             {
                                 returnHTTP.Add(new Target() { SiteId = site.Id, Host = binding.Host, WebRootPath = site.Applications["/"].VirtualDirectories["/"].PhysicalPath, PluginName = Name });
                             }
-                            if (!String.IsNullOrEmpty(binding.Host) && binding.Protocol == "https")
+                            //Get HTTPS sites that aren't IDN
+                            if (!String.IsNullOrEmpty(binding.Host) && binding.Protocol == "https" && !Regex.IsMatch(binding.Host, @"[^\u0000-\u007F]"))
                             {
                                 siteHTTPS.Add(new Target() { SiteId = site.Id, Host = binding.Host, WebRootPath = site.Applications["/"].VirtualDirectories["/"].PhysicalPath, PluginName = Name });
                             }

--- a/letsencrypt-win-simple/Program.cs
+++ b/letsencrypt-win-simple/Program.cs
@@ -168,11 +168,62 @@ namespace LetsEncrypt.ACME.Simple
                         }
                         else
                         {
-                            var count = 1;
-                            foreach (var binding in targets)
+                            int HostsPerPage = 50;
+                            try
                             {
-                                Console.WriteLine($" {count}: {binding}");
-                                count++;
+                                HostsPerPage = Properties.Settings.Default.HostsPerPage;
+                            }
+                            catch (Exception ex)
+                            {
+                                Log.Error("Error getting HostsPerPage setting, setting to default value. Error: {@ex}", ex);
+                            }
+                            var count = 1;
+                            if (targets.Count > HostsPerPage)
+                            {
+                                do
+                                {
+                                    if ((count + HostsPerPage) <= targets.Count)
+                                    {
+                                        int stop = count + HostsPerPage;
+                                        for (int i = count; i < stop; i++)
+                                        {
+                                            Console.WriteLine($" {count}: {targets[count-1]}");
+                                            count++;
+                                        }
+                                    }
+                                    else
+                                    {
+                                        for (int i = count; i<= targets.Count; i++)
+                                        {
+                                            Console.WriteLine($" {count}: {targets[count - 1]}");
+                                            count++;
+                                        }
+                                    }
+
+                                    if (count < targets.Count)
+                                    {
+                                        Console.WriteLine(" Q: Quit");
+                                        Console.Write("Press enter to continue to next page ");
+                                        var continueResponse = Console.ReadLine().ToLowerInvariant();
+                                        switch (continueResponse)
+                                        {
+                                            case "q":
+                                                throw new Exception($"Requested to quit application");
+                                            default:
+                                                break;
+                                        }
+                                    }
+
+                                }
+                                while (count < targets.Count);
+                            }
+                            else
+                            {
+                                foreach (var binding in targets)
+                                {
+                                    Console.WriteLine($" {count}: {binding}");
+                                    count++;
+                                }
                             }
                         }
 

--- a/letsencrypt-win-simple/Properties/Settings.Designer.cs
+++ b/letsencrypt-win-simple/Properties/Settings.Designer.cs
@@ -49,5 +49,14 @@ namespace LetsEncrypt.ACME.Simple.Properties {
                 return ((int)(this["RSAKeyBits"]));
             }
         }
+        
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("50")]
+        public int HostsPerPage {
+            get {
+                return ((int)(this["HostsPerPage"]));
+            }
+        }
     }
 }

--- a/letsencrypt-win-simple/Properties/Settings.settings
+++ b/letsencrypt-win-simple/Properties/Settings.settings
@@ -11,5 +11,8 @@
     <Setting Name="RSAKeyBits" Type="System.Int32" Scope="Application">
       <Value Profile="(Default)">2048</Value>
     </Setting>
+    <Setting Name="HostsPerPage" Type="System.Int32" Scope="Application">
+      <Value Profile="(Default)">50</Value>
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
Added pages of hosts instead of a single list.
Added a param to hide existing bindings that already have HTTPS bindings
IDN domains are not supported by Let's Encrypt at this time, so removing
them.