### PR TITLE
Added a CertificatePath option to App.config

### DIFF
--- a/letsencrypt-win-simple/App.config
+++ b/letsencrypt-win-simple/App.config
@@ -28,7 +28,7 @@
         <value>50</value>
       </setting>
       <setting name="CertificatePath" serializeAs="String">
-        <value></value>
+        <value>Certificates</value>
       </setting>
     </LetsEncrypt.ACME.Simple.Properties.Settings>
   </applicationSettings>

--- a/letsencrypt-win-simple/App.config
+++ b/letsencrypt-win-simple/App.config
@@ -28,7 +28,7 @@
         <value>50</value>
       </setting>
       <setting name="CertificatePath" serializeAs="String">
-        <value>Certificates</value>
+        <value></value>
       </setting>
     </LetsEncrypt.ACME.Simple.Properties.Settings>
   </applicationSettings>

--- a/letsencrypt-win-simple/App.config
+++ b/letsencrypt-win-simple/App.config
@@ -27,6 +27,9 @@
       <setting name="HostsPerPage" serializeAs="String">
         <value>50</value>
       </setting>
+      <setting name="CertificatePath" serializeAs="String">
+        <value></value>
+      </setting>
     </LetsEncrypt.ACME.Simple.Properties.Settings>
   </applicationSettings>
   <runtime>

--- a/letsencrypt-win-simple/Program.cs
+++ b/letsencrypt-win-simple/Program.cs
@@ -87,16 +87,19 @@ namespace LetsEncrypt.ACME.Simple
             {
                 certificatePath = configPath;
             }
+            else
+            {
+                try
+                {
+                    Directory.CreateDirectory(certificatePath);
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Error creating the certificate directory, {certificatePath}. Defaulting to config path");
+                    Log.Warning("Error creating the certificate directory, {certificatePath}. Defaulting to config path. Error: {@ex}", certificatePath, ex);
 
-            try
-            {
-                Directory.CreateDirectory(certificatePath);
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine("Error creating the certificate directory: " + certificatePath);
-                Log.Error("Error creating the certificate directory. Error: {@ex}", ex);
-                return;
+                    certificatePath = configPath;
+                }
             }
 
             Console.WriteLine("Certificate Folder: " + certificatePath);

--- a/letsencrypt-win-simple/Program.cs
+++ b/letsencrypt-win-simple/Program.cs
@@ -82,13 +82,24 @@ namespace LetsEncrypt.ACME.Simple
             Directory.CreateDirectory(configPath);
 
             certificatePath = Properties.Settings.Default.CertificatePath;
+
             if (string.IsNullOrWhiteSpace(certificatePath))
             {
                 certificatePath = configPath;
             }
+
+            try
+            {
+                Directory.CreateDirectory(certificatePath);
+            }
+            catch (Exception ex)
+            {
+                Log.Error("Error creating the certificate directory. Error: {@ex}", ex);
+                return;
+            }
+
             Console.WriteLine("Certificate Folder: " + certificatePath);
             Log.Information("Certificate Folder: {certificatePath}", certificatePath);
-            Directory.CreateDirectory(certificatePath);
 
             try
             {

--- a/letsencrypt-win-simple/Program.cs
+++ b/letsencrypt-win-simple/Program.cs
@@ -24,6 +24,7 @@ namespace LetsEncrypt.ACME.Simple
         const string clientName = "letsencrypt-win-simple";
         public static string BaseURI { get; set; }
         static string configPath;
+        static string certificatePath;
         static Settings settings;
         static AcmeClient client;
         public static Options Options;
@@ -79,6 +80,15 @@ namespace LetsEncrypt.ACME.Simple
             Console.WriteLine("Config Folder: " + configPath);
             Log.Information("Config Folder: {configPath}", configPath);
             Directory.CreateDirectory(configPath);
+
+            certificatePath = Properties.Settings.Default.CertificatePath;
+            if (string.IsNullOrWhiteSpace(certificatePath))
+            {
+                certificatePath = configPath;
+            }
+            Console.WriteLine("Certificate Folder: " + certificatePath);
+            Log.Information("Certificate Folder: {certificatePath}", certificatePath);
+            Directory.CreateDirectory(certificatePath);
 
             try
             {
@@ -502,16 +512,16 @@ namespace LetsEncrypt.ACME.Simple
 
             if (certRequ.StatusCode == System.Net.HttpStatusCode.Created)
             {
-                var keyGenFile = Path.Combine(configPath, $"{dnsIdentifier}-gen-key.json");
-                var keyPemFile = Path.Combine(configPath, $"{dnsIdentifier}-key.pem");
-                var csrGenFile = Path.Combine(configPath, $"{dnsIdentifier}-gen-csr.json");
-                var csrPemFile = Path.Combine(configPath, $"{dnsIdentifier}-csr.pem");
-                var crtDerFile = Path.Combine(configPath, $"{dnsIdentifier}-crt.der");
-                var crtPemFile = Path.Combine(configPath, $"{dnsIdentifier}-crt.pem");
+                var keyGenFile = Path.Combine(certificatePath, $"{dnsIdentifier}-gen-key.json");
+                var keyPemFile = Path.Combine(certificatePath, $"{dnsIdentifier}-key.pem");
+                var csrGenFile = Path.Combine(certificatePath, $"{dnsIdentifier}-gen-csr.json");
+                var csrPemFile = Path.Combine(certificatePath, $"{dnsIdentifier}-csr.pem");
+                var crtDerFile = Path.Combine(certificatePath, $"{dnsIdentifier}-crt.der");
+                var crtPemFile = Path.Combine(certificatePath, $"{dnsIdentifier}-crt.pem");
                 string crtPfxFile = null;
                 if (!CentralSSL)
                 {
-                    crtPfxFile = Path.Combine(configPath, $"{dnsIdentifier}-all.pfx");
+                    crtPfxFile = Path.Combine(certificatePath, $"{dnsIdentifier}-all.pfx");
                 }
                 else
                 {
@@ -756,8 +766,8 @@ namespace LetsEncrypt.ACME.Simple
                         var sigalg = cacert.SignatureAlgorithm?.FriendlyName;
                         var sigval = cacert.GetCertHashString();
 
-                        var cacertDerFile = Path.Combine(configPath, $"ca-{sernum}-crt.der");
-                        var cacertPemFile = Path.Combine(configPath, $"ca-{sernum}-crt.pem");
+                        var cacertDerFile = Path.Combine(certificatePath, $"ca-{sernum}-crt.der");
+                        var cacertPemFile = Path.Combine(certificatePath, $"ca-{sernum}-crt.pem");
 
                         if (!File.Exists(cacertDerFile))
                             File.Copy(tmp, cacertDerFile, true);

--- a/letsencrypt-win-simple/Program.cs
+++ b/letsencrypt-win-simple/Program.cs
@@ -94,6 +94,7 @@ namespace LetsEncrypt.ACME.Simple
             }
             catch (Exception ex)
             {
+                Console.WriteLine("Error creating the certificate directory: " + certificatePath);
                 Log.Error("Error creating the certificate directory. Error: {@ex}", ex);
                 return;
             }

--- a/letsencrypt-win-simple/Properties/Settings.Designer.cs
+++ b/letsencrypt-win-simple/Properties/Settings.Designer.cs
@@ -58,5 +58,14 @@ namespace LetsEncrypt.ACME.Simple.Properties {
                 return ((int)(this["HostsPerPage"]));
             }
         }
+        
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string CertificatePath {
+            get {
+                return ((string)(this["CertificatePath"]));
+            }
+        }
     }
 }

--- a/letsencrypt-win-simple/Properties/Settings.settings
+++ b/letsencrypt-win-simple/Properties/Settings.settings
@@ -14,5 +14,8 @@
     <Setting Name="HostsPerPage" Type="System.Int32" Scope="Application">
       <Value Profile="(Default)">50</Value>
     </Setting>
+    <Setting Name="CertificatePath" Type="System.String" Scope="Application">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/letsencrypt-win-simple/Web_Config.xml
+++ b/letsencrypt-win-simple/Web_Config.xml
@@ -4,13 +4,10 @@
 		<staticContent>
 			<mimeMap fileExtension="*" mimeType="text/json" />
 		</staticContent>
-		<handlers>
-			<add name="AcmeChallenge" path=".well-known/acme-challenge/*" verb="*" modules="StaticFileModule,DefaultDocumentModule" resourceType="Either" requireAccess="Read" />
-		</handlers>
 	</system.webServer>
-	<system.web>
-		<authorization>
-			<allow users="*" />
-		</authorization>
-	</system.web>
+  <system.web>
+    <authorization>
+      <allow users="*" />
+    </authorization>
+  </system.web>
 </configuration>

--- a/letsencrypt-win-simple/Web_Config.xml
+++ b/letsencrypt-win-simple/Web_Config.xml
@@ -4,9 +4,6 @@
 		<staticContent>
 			<mimeMap fileExtension="*" mimeType="text/json" />
 		</staticContent>
-		<handlers>
-			<add name="AcmeChallenge" path=".well-known/acme-challenge/*" verb="*" modules="StaticFileModule,DefaultDocumentModule" resourceType="Either" requireAccess="Read" />
-		</handlers>
 	</system.webServer>
 	<system.web>
 		<authorization>

--- a/letsencrypt-win-simple/Web_Config.xml
+++ b/letsencrypt-win-simple/Web_Config.xml
@@ -4,6 +4,9 @@
 		<staticContent>
 			<mimeMap fileExtension="*" mimeType="text/json" />
 		</staticContent>
+		<handlers>
+			<add name="AcmeChallenge" path=".well-known/acme-challenge/*" verb="*" modules="StaticFileModule,DefaultDocumentModule" resourceType="Either" requireAccess="Read" />
+		</handlers>
 	</system.webServer>
 	<system.web>
 		<authorization>

--- a/letsencrypt-win-simple/Web_Config.xml
+++ b/letsencrypt-win-simple/Web_Config.xml
@@ -5,9 +5,9 @@
 			<mimeMap fileExtension="*" mimeType="text/json" />
 		</staticContent>
 	</system.webServer>
-  <system.web>
-    <authorization>
-      <allow users="*" />
-    </authorization>
-  </system.web>
+	<system.web>
+		<authorization>
+			<allow users="*" />
+		</authorization>
+	</system.web>
 </configuration>


### PR DESCRIPTION
I wanted to override the default location ([Drive]:\Users\[User]\AppData\Roaming\letsencrypt-win-simple\httpsacme-v01.api.letsencrypt.org) where certificates and request files are stored. Therefore I added an 'CertificatePath' element to App.config where you can specify a relative or absolute path. 
```
<setting name="CertificatePath" serializeAs="String">
    <value>c:\certificates</value>
</setting>
```
Leaving the value empty still resolves to the default location