### PR TITLE
Use '.' for MIME type extension

### DIFF
--- a/letsencrypt-win-simple/Web_Config.xml
+++ b/letsencrypt-win-simple/Web_Config.xml
@@ -2,7 +2,7 @@
 <configuration>
 	<system.webServer>
 		<staticContent>
-			<mimeMap fileExtension="*" mimeType="text/json" />
+			<mimeMap fileExtension="." mimeType="text/json" />
 		</staticContent>
 	</system.webServer>
   <system.web>


### PR DESCRIPTION
I recently encountered an issue with an IIS server not serving the tokens due to an issue with the static file handler:

```
HTTP Error 404.17 - Not Found
    The requested content appears to be script and will not
    be served by the static file handler.
```

It is quite a simple fix, changing the MIME type extension to `.` instead of `*`. Further information in the following:

http://stackoverflow.com/questions/20385026/404-17-error-showing-after-adding-a-wildcard-mime-type-iis-7 