### PR TITLE
Explicitly enable TLS 1.0, 1.1 and 1.2

### DIFF
--- a/letsencrypt-win-simple/Program.cs
+++ b/letsencrypt-win-simple/Program.cs
@@ -39,6 +39,8 @@ namespace LetsEncrypt.ACME.Simple
                 .CreateLogger();
             Log.Information("The global logger has been configured");
 
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
+
             var commandLineParseResult = Parser.Default.ParseArguments<Options>(args);
             var parsed = commandLineParseResult as Parsed<Options>;
             if (parsed == null)


### PR DESCRIPTION
For some bizzare reason, TLS 1.2 is not enabled by default in .NET. This results in an error when communicating with the API if you have disabled TLS 1.0 on your web server as per best practices. 

```
Let's Encrypt (Simple Windows ACME Client)

ACME Server: https://acme-v01.api.letsencrypt.org/
Config Folder: C:\[...]\letsencrypt-win-simple\httpsacme-v01.api.letsencrypt.org
Loading Signer from C:\[...]\letsencrypt-win-simple\httpsacme-v01.api.letsencrypt.org\Signer
System.Net.WebException: The request was aborted: Could not create SSL/TLS secure channel.
   at System.Net.HttpWebRequest.GetResponse()
   at ACMESharp.AcmeClient.RequestHttpGet(Uri uri)
   at ACMESharp.AcmeClient.Init()
   at LetsEncrypt.ACME.Simple.Program.Main(String[] args) in [...]
```

This PR explicitly enables TLS 1.0, 1.1 and 1.2, which are all the protocols that are supported by the API server. As it is an application wide setting, I have added it very early in `Main()`.