### PR TITLE
Run under SYSTEM profile by default

### DIFF
--- a/letsencrypt-win-simple/Options.cs
+++ b/letsencrypt-win-simple/Options.cs
@@ -36,6 +36,9 @@ namespace LetsEncrypt.ACME.Simple
         [Option(HelpText = "Certificates per site instead of per host")]
         public bool SAN { get; set; }
 
+        [Option(Default = false, HelpText = "Use user profile storage (The default is to use the SYSTEM profile)")]
+        public bool User { get; set; }
+
         // can't easily make this a command line option since it would have to be saved
         //[Option(Default = 60f, HelpText = "Renewal period in days. Can be set to negative to test.")]
         //public float RenewalPeriod { get; set; } = 60;

--- a/letsencrypt-win-simple/Program.cs
+++ b/letsencrypt-win-simple/Program.cs
@@ -76,7 +76,14 @@ namespace LetsEncrypt.ACME.Simple
 
             settings = new Settings(clientName, BaseURI);
             Log.Debug("{@settings}", settings);
-            configPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), clientName, CleanFileName(BaseURI));
+            if (Options.User)
+            {
+                configPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), clientName, CleanFileName(BaseURI));
+            }
+            else
+            {
+                configPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "config", "systemprofile", "AppData", "Local", clientName, CleanFileName(BaseURI));
+            }
             Console.WriteLine("Config Folder: " + configPath);
             Log.Information("Config Folder: {configPath}", configPath);
             Directory.CreateDirectory(configPath);
@@ -664,9 +671,23 @@ namespace LetsEncrypt.ACME.Simple
                     var currentExec = Assembly.GetExecutingAssembly().Location;
 
                     // Create an action that will launch the app with the renew paramaters whenever the trigger fires
-                    task.Actions.Add(new ExecAction(currentExec, $"--renew --baseuri \"{BaseURI}\"", Path.GetDirectoryName(currentExec)));
+                    var arguments = $"--renew --baseuri \"{BaseURI}\"";
+                    if (Options.User)
+                    {
+                        arguments += " --user";
+                    }
+                    if (Options.Test)
+                    {
+                        arguments += " --test";
+                    }
+                    task.Actions.Add(new ExecAction(currentExec, arguments, Path.GetDirectoryName(currentExec)));
 
                     task.Principal.RunLevel = TaskRunLevel.Highest; // need admin
+                    if (!Options.User)
+                    {
+                        task.Principal.UserId = "NT AUTHORITY\\SYSTEM";
+                        task.Principal.LogonType = TaskLogonType.ServiceAccount;
+                    }
                     Log.Debug("{@task}", task);
 
                     // Register the task in the root folder


### PR DESCRIPTION
This PR will store data under the SYSTEM profile by default, I feel this is a better stance for servers as opposed to a per user configuration. Additionally, this means tasks are set to run as SYSTEM without requiring the user to be logged on (https://github.com/Lone-Coder/letsencrypt-win-simple/wiki/Windows-Task-Scheduler-Settings), which was in fact the primary goal of this PR. 

The current behaviour of user storage and tasks and be enabled using the `--user` command line option.