### PR TITLE
SAN/ Cleanup/ RenewalDays/ CertificateStore Work

### DIFF
--- a/letsencrypt-win-simple/App.config
+++ b/letsencrypt-win-simple/App.config
@@ -28,7 +28,13 @@
         <value>50</value>
       </setting>
       <setting name="CertificatePath" serializeAs="String">
-        <value></value>
+        <value />
+      </setting>
+      <setting name="RenewalDays" serializeAs="String">
+        <value>60</value>
+      </setting>
+      <setting name="CertificateStore" serializeAs="String">
+        <value>WebHosting</value>
       </setting>
     </LetsEncrypt.ACME.Simple.Properties.Settings>
   </applicationSettings>

--- a/letsencrypt-win-simple/ObjectExtensions.cs
+++ b/letsencrypt-win-simple/ObjectExtensions.cs
@@ -1,0 +1,132 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using System.ArrayExtensions;
+
+namespace System
+{
+    //From https://github.com/Burtsev-Alexey/net-object-deep-copy
+    public static class ObjectExtensions
+    {
+        private static readonly MethodInfo CloneMethod = typeof(Object).GetMethod("MemberwiseClone", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        public static bool IsPrimitive(this Type type)
+        {
+            if (type == typeof(String)) return true;
+            return (type.IsValueType & type.IsPrimitive);
+        }
+
+        public static Object Copy(this Object originalObject)
+        {
+            return InternalCopy(originalObject, new Dictionary<Object, Object>(new ReferenceEqualityComparer()));
+        }
+        private static Object InternalCopy(Object originalObject, IDictionary<Object, Object> visited)
+        {
+            if (originalObject == null) return null;
+            var typeToReflect = originalObject.GetType();
+            if (IsPrimitive(typeToReflect)) return originalObject;
+            if (visited.ContainsKey(originalObject)) return visited[originalObject];
+            if (typeof(Delegate).IsAssignableFrom(typeToReflect)) return null;
+            var cloneObject = CloneMethod.Invoke(originalObject, null);
+            if (typeToReflect.IsArray)
+            {
+                var arrayType = typeToReflect.GetElementType();
+                if (IsPrimitive(arrayType) == false)
+                {
+                    Array clonedArray = (Array)cloneObject;
+                    clonedArray.ForEach((array, indices) => array.SetValue(InternalCopy(clonedArray.GetValue(indices), visited), indices));
+                }
+
+            }
+            visited.Add(originalObject, cloneObject);
+            CopyFields(originalObject, visited, cloneObject, typeToReflect);
+            RecursiveCopyBaseTypePrivateFields(originalObject, visited, cloneObject, typeToReflect);
+            return cloneObject;
+        }
+
+        private static void RecursiveCopyBaseTypePrivateFields(object originalObject, IDictionary<object, object> visited, object cloneObject, Type typeToReflect)
+        {
+            if (typeToReflect.BaseType != null)
+            {
+                RecursiveCopyBaseTypePrivateFields(originalObject, visited, cloneObject, typeToReflect.BaseType);
+                CopyFields(originalObject, visited, cloneObject, typeToReflect.BaseType, BindingFlags.Instance | BindingFlags.NonPublic, info => info.IsPrivate);
+            }
+        }
+
+        private static void CopyFields(object originalObject, IDictionary<object, object> visited, object cloneObject, Type typeToReflect, BindingFlags bindingFlags = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.FlattenHierarchy, Func<FieldInfo, bool> filter = null)
+        {
+            foreach (FieldInfo fieldInfo in typeToReflect.GetFields(bindingFlags))
+            {
+                if (filter != null && filter(fieldInfo) == false) continue;
+                if (IsPrimitive(fieldInfo.FieldType)) continue;
+                var originalFieldValue = fieldInfo.GetValue(originalObject);
+                var clonedFieldValue = InternalCopy(originalFieldValue, visited);
+                fieldInfo.SetValue(cloneObject, clonedFieldValue);
+            }
+        }
+        public static T Copy<T>(this T original)
+        {
+            return (T)Copy((Object)original);
+        }
+    }
+
+    public class ReferenceEqualityComparer : EqualityComparer<Object>
+    {
+        public override bool Equals(object x, object y)
+        {
+            return ReferenceEquals(x, y);
+        }
+        public override int GetHashCode(object obj)
+        {
+            if (obj == null) return 0;
+            return obj.GetHashCode();
+        }
+    }
+
+    namespace ArrayExtensions
+    {
+        public static class ArrayExtensions
+        {
+            public static void ForEach(this Array array, Action<Array, int[]> action)
+            {
+                if (array.LongLength == 0) return;
+                ArrayTraverse walker = new ArrayTraverse(array);
+                do action(array, walker.Position);
+                while (walker.Step());
+            }
+        }
+
+        internal class ArrayTraverse
+        {
+            public int[] Position;
+            private int[] maxLengths;
+
+            public ArrayTraverse(Array array)
+            {
+                maxLengths = new int[array.Rank];
+                for (int i = 0; i < array.Rank; ++i)
+                {
+                    maxLengths[i] = array.GetLength(i) - 1;
+                }
+                Position = new int[array.Rank];
+            }
+
+            public bool Step()
+            {
+                for (int i = 0; i < Position.Length; ++i)
+                {
+                    if (Position[i] < maxLengths[i])
+                    {
+                        Position[i]++;
+                        for (int j = 0; j < i; j++)
+                        {
+                            Position[j] = 0;
+                        }
+                        return true;
+                    }
+                }
+                return false;
+            }
+        }
+    }
+
+}

--- a/letsencrypt-win-simple/Options.cs
+++ b/letsencrypt-win-simple/Options.cs
@@ -10,15 +10,15 @@ namespace LetsEncrypt.ACME.Simple
     class Options
     {
         [Option(Default = "https://acme-v01.api.letsencrypt.org/", HelpText = "The address of the ACME server to use.")]
-        public string BaseURI { get; set; }
+        public string BaseUri { get; set; }
 
         [Option(HelpText = "Accept the terms of service.")]
-        public bool AcceptTOS { get; set; }
+        public bool AcceptTos { get; set; }
 
         [Option(HelpText = "Check for renewals.")]
         public bool Renew { get; set; }
 
-        [Option(HelpText = "Overrides BaseURI setting to https://acme-staging.api.letsencrypt.org/")]
+        [Option(HelpText = "Overrides BaseUri setting to https://acme-staging.api.letsencrypt.org/")]
         public bool Test { get; set; }
 
         [Option(HelpText = "A host name to manually get a certificate for. --webroot must also be set.")]
@@ -28,13 +28,13 @@ namespace LetsEncrypt.ACME.Simple
         public string WebRoot { get; set; }
 
         [Option(HelpText = "Path for Centralized Certificate Store (This enables Centralized SSL). Ex. \\\\storage\\central_ssl\\")]
-        public string CentralSSLStore { get; set; }
+        public string CentralSslStore { get; set; }
 
         [Option(HelpText = "Hide sites that have existing HTTPS bindings")]
-        public bool HideHTTPS { get; set; }
+        public bool HideHttps { get; set; }
 
         [Option(HelpText = "Certificates per site instead of per host")]
-        public bool SAN { get; set; }
+        public bool San { get; set; }
 
         // can't easily make this a command line option since it would have to be saved
         //[Option(Default = 60f, HelpText = "Renewal period in days. Can be set to negative to test.")]

--- a/letsencrypt-win-simple/Plugin/IISPlugin.cs
+++ b/letsencrypt-win-simple/Plugin/IISPlugin.cs
@@ -16,7 +16,7 @@ namespace LetsEncrypt.ACME.Simple
     {
         public override string Name => "IIS";
 
-        static Version iisVersion;
+        private static Version _iisVersion;
 
         public override List<Target> GetTargets()
         {
@@ -25,8 +25,8 @@ namespace LetsEncrypt.ACME.Simple
 
             var result = new List<Target>();
 
-            iisVersion = GetIisVersion();
-            if (iisVersion.Major == 0)
+            _iisVersion = GetIisVersion();
+            if (_iisVersion.Major == 0)
             {
                 Console.WriteLine(" IIS Version not found in windows registry. Skipping scan.");
                 Log.Information("IIS Version not found in windows registry. Skipping scan.");
@@ -62,7 +62,7 @@ namespace LetsEncrypt.ACME.Simple
                         }
 
                         siteHTTP.AddRange(returnHTTP);
-                        if (Program.Options.HideHTTPS == true)
+                        if (Program.Options.HideHttps == true)
                         {
                             foreach (var bindingHTTPS in siteHTTPS)
                             {
@@ -93,6 +93,7 @@ namespace LetsEncrypt.ACME.Simple
 
             return result;
         }
+
         public override List<Target> GetSites()
         {
 
@@ -101,8 +102,8 @@ namespace LetsEncrypt.ACME.Simple
 
             var result = new List<Target>();
 
-            iisVersion = GetIisVersion();
-            if (iisVersion.Major == 0)
+            _iisVersion = GetIisVersion();
+            if (_iisVersion.Major == 0)
             {
                 Console.WriteLine(" IIS Version not found in windows registry. Skipping scan.");
                 Log.Information("IIS Version not found in windows registry. Skipping scan.");
@@ -114,29 +115,29 @@ namespace LetsEncrypt.ACME.Simple
                     foreach (var site in iisManager.Sites)
                     {
                         List<Target> returnHTTP = new List<Target>();
-                        List<string> Hosts = new List<string>();
+                        List<string> hosts = new List<string>();
 
                         foreach (var binding in site.Bindings)
                         {
                             //Get HTTP sites that aren't IDN
                             if (!String.IsNullOrEmpty(binding.Host) && binding.Protocol == "http" && !Regex.IsMatch(binding.Host, @"[^\u0000-\u007F]"))
                             {
-                                if (Hosts.Where(h => h == binding.Host).Count() == 0)
+                                if (hosts.Where(h => h == binding.Host).Count() == 0)
                                 {
-                                    Hosts.Add(binding.Host);
+                                    hosts.Add(binding.Host);
                                 }
 
                                 returnHTTP.Add(new Target() { SiteId = site.Id, Host = binding.Host, WebRootPath = site.Applications["/"].VirtualDirectories["/"].PhysicalPath, PluginName = Name });
                             }
                         }
-                        if (Hosts.Count <= 100)
+                        if (hosts.Count <= 100)
                         {
-                            result.Add(new Target() { SiteId = site.Id, Host = site.Name, WebRootPath = site.Applications["/"].VirtualDirectories["/"].PhysicalPath, PluginName = Name, AlternativeNames = Hosts });
+                            result.Add(new Target() { SiteId = site.Id, Host = site.Name, WebRootPath = site.Applications["/"].VirtualDirectories["/"].PhysicalPath, PluginName = Name, AlternativeNames = hosts });
                         }
                         else
                         {
                             Console.WriteLine($" {site.Name} has too many hosts for a SAN certificate. Let's Encrypt currently has a maximum of 100 alternative names per certificate.");
-                            Log.Error("{Name} has too many hosts for a SAN certificate. Let's Encrypt currently has a maximum of 100 alternative names per certificate.", site.Name);
+                            Log.Error("{Name} has too many hosts for a San certificate. Let's Encrypt currently has a maximum of 100 alternative names per certificate.", site.Name);
                         }
                     }
                 }
@@ -151,7 +152,7 @@ namespace LetsEncrypt.ACME.Simple
             return result;
         }
 
-        string sourceFilePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "web_config.xml");
+        private readonly string _sourceFilePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "web_config.xml");
 
         public override void BeforeAuthorize(Target target, string answerPath)
         {
@@ -160,7 +161,7 @@ namespace LetsEncrypt.ACME.Simple
             
             Console.WriteLine($" Writing web.config to add extensionless mime type to {webConfigPath}");
             Log.Information("Writing web.config to add extensionless mime type to {webConfigPath}", webConfigPath);
-            File.Copy(sourceFilePath, webConfigPath, true);
+            File.Copy(_sourceFilePath, webConfigPath, true);
         }
 
         public override void OnAuthorizeFail(Target target)
@@ -173,8 +174,8 @@ files. Here's how to fix that:
 2. Move the StaticFile mapping above the ExtensionlessUrlHandler mappings.
 (like this http://i.stack.imgur.com/nkvrL.png)
 3. If you need to make changes to your web.config file, update the one
-at " + sourceFilePath);
-            Log.Error("Authorize failed: This could be caused by IIS not being setup to handle extensionless static files.Here's how to fix that: 1.In IIS manager goto Site/ Server->Handler Mappings->View Ordered List 2.Move the StaticFile mapping above the ExtensionlessUrlHandler mappings. (like this http://i.stack.imgur.com/nkvrL.png) 3.If you need to make changes to your web.config file, update the one at {sourceFilePath}", sourceFilePath);
+at " + _sourceFilePath);
+            Log.Error("Authorize failed: This could be caused by IIS not being setup to handle extensionless static files.Here's how to fix that: 1.In IIS manager goto Site/ Server->Handler Mappings->View Ordered List 2.Move the StaticFile mapping above the ExtensionlessUrlHandler mappings. (like this http://i.stack.imgur.com/nkvrL.png) 3.If you need to make changes to your web.config file, update the one at {_sourceFilePath}", _sourceFilePath);
         }
 
         public override void Install(Target target, string pfxFilename, X509Store store, X509Certificate2 certificate)
@@ -183,7 +184,7 @@ at " + sourceFilePath);
             {
                 var site = GetSite(target, iisManager);
                 List<string> hosts = new List<string>();
-                if (!Program.Options.SAN)
+                if (!Program.Options.San)
                 {
                     hosts.Add(target.Host);
                 }
@@ -209,7 +210,7 @@ at " + sourceFilePath);
                         Console.WriteLine($" Adding https Binding");
                         Log.Information("Adding https Binding");
                         var existingHTTPBinding = (from b in site.Bindings where b.Host == host && b.Protocol == "http" select b).FirstOrDefault();
-                        if (existingHTTPBinding != null) //This is a fix for the multiple site SAN cert
+                        if (existingHTTPBinding != null) //This is a fix for the multiple site San cert
                         {
                             string HTTPEndpoint = existingHTTPBinding.EndPoint.ToString();
                             string IP = HTTPEndpoint.Remove(HTTPEndpoint.IndexOf(':'), (HTTPEndpoint.Length - HTTPEndpoint.IndexOf(':')));
@@ -222,7 +223,7 @@ at " + sourceFilePath);
                             var iisBinding = site.Bindings.Add(IP + ":443:" + host, certificate.GetCertHash(), store.Name);
                             iisBinding.Protocol = "https";
 
-                            if (iisVersion.Major >= 8)
+                            if (_iisVersion.Major >= 8)
                                 iisBinding.SetAttributeValue("sslFlags", 1); // Enable SNI support
                         }
                     }
@@ -243,7 +244,7 @@ at " + sourceFilePath);
                     var site = GetSite(target, iisManager);
 
                     List<string> hosts = new List<string>();
-                    if (!Program.Options.SAN)
+                    if (!Program.Options.San)
                     {
                         hosts.Add(target.Host);
                     }
@@ -256,14 +257,14 @@ at " + sourceFilePath);
                         {
                             Console.WriteLine($" Updating Existing https Binding");
                             Log.Information("Updating Existing https Binding");
-                            if (iisVersion.Major >= 8 && existingBinding.GetAttributeValue("sslFlags").ToString() != "2")
+                            if (_iisVersion.Major >= 8 && existingBinding.GetAttributeValue("sslFlags").ToString() != "2")
                             {
                                 //IIS 8+ and not using centralized SSL
                                 existingBinding.CertificateStoreName = null;
                                 existingBinding.CertificateHash = null;
                                 existingBinding.SetAttributeValue("sslFlags", 2);
                             }
-                            else if (!(iisVersion.Major >= 8))
+                            else if (!(_iisVersion.Major >= 8))
                             {
                                 Log.Error("You aren't using IIS 8 or greater, so centralized SSL is not supported");
                                 //Not using IIS 8+ so can't set centralized certificates
@@ -275,7 +276,7 @@ at " + sourceFilePath);
                             Console.WriteLine($" Adding Central SSL https Binding");
                             Log.Information("Adding Central SSL https Binding");
                             var existingHTTPBinding = (from b in site.Bindings where b.Host == host && b.Protocol == "http" select b).FirstOrDefault();
-                            if (existingHTTPBinding != null) //This is a fix for the multiple site SAN cert
+                            if (existingHTTPBinding != null) //This is a fix for the multiple site San cert
                             {
                                 string HTTPEndpoint = existingHTTPBinding.EndPoint.ToString();
                                 string IP = HTTPEndpoint.Remove(HTTPEndpoint.IndexOf(':'), (HTTPEndpoint.Length - HTTPEndpoint.IndexOf(':')));
@@ -287,7 +288,7 @@ at " + sourceFilePath);
 
                                 var iisBinding = site.Bindings.Add(IP + ":443:" + host, "https");
 
-                                if (iisVersion.Major >= 8)
+                                if (_iisVersion.Major >= 8)
                                     iisBinding.SetAttributeValue("sslFlags", 2); // Enable Centralized Certificate Store
                             }
                         }
@@ -331,7 +332,7 @@ at " + sourceFilePath);
             Console.WriteLine(" WARNING: Unable to renew.");
         }
 
-        Site GetSite(Target target, ServerManager iisManager)
+        private Site GetSite(Target target, ServerManager iisManager)
         {
             foreach (var site in iisManager.Sites)
             {

--- a/letsencrypt-win-simple/Plugin/ManualPlugin.cs
+++ b/letsencrypt-win-simple/Plugin/ManualPlugin.cs
@@ -64,11 +64,12 @@ namespace LetsEncrypt.ACME.Simple
                 var hostName = Console.ReadLine();
                 string[] alternativeNames = null;
 
-                if(Program.Options.SAN)
+                if(Program.Options.San)
                 {
                     Console.Write("Enter all Alternative Names seperated by a comma ");
-                    var SANInput = Console.ReadLine();
-                    alternativeNames = SANInput.Split(',');
+                    Console.SetIn(new System.IO.StreamReader(Console.OpenStandardInput(8192)));
+                    var sanInput = Console.ReadLine();
+                    alternativeNames = sanInput.Split(',');
 
                 }
 
@@ -79,17 +80,17 @@ namespace LetsEncrypt.ACME.Simple
 
                 // TODO: make a system where they can execute a program/batch file to update whatever they need after install.
 
-                List<string> SANList = new List<string>(alternativeNames);
-                if (SANList.Count <= 100)
+                List<string> sanList = new List<string>(alternativeNames);
+                if (sanList.Count <= 100)
                 {
 
-                    var target = new Target() { Host = hostName, WebRootPath = physicalPath, PluginName = Name, AlternativeNames = SANList };
+                    var target = new Target() { Host = hostName, WebRootPath = physicalPath, PluginName = Name, AlternativeNames = sanList };
                     Program.Auto(target);
                 }
                 else
                 {
                     Console.WriteLine($" You entered too many hosts for a SAN certificate. Let's Encrypt currently has a maximum of 100 alternative names per certificate.");
-                    Log.Error("You entered too many hosts for a SAN certificate. Let's Encrypt currently has a maximum of 100 alternative names per certificate.");
+                    Log.Error("You entered too many hosts for a San certificate. Let's Encrypt currently has a maximum of 100 alternative names per certificate.");
                 }
             }
         }

--- a/letsencrypt-win-simple/Plugin/Plugin.cs
+++ b/letsencrypt-win-simple/Plugin/Plugin.cs
@@ -24,7 +24,7 @@ namespace LetsEncrypt.ACME.Simple
         public abstract List<Target> GetTargets();
 
         /// <summary>
-        /// Generates a list of sites that SAN certificates can be created for.
+        /// Generates a list of sites that San certificates can be created for.
         /// </summary>
         /// <returns></returns>
         public abstract List<Target> GetSites();

--- a/letsencrypt-win-simple/Properties/AssemblyInfo.cs
+++ b/letsencrypt-win-simple/Properties/AssemblyInfo.cs
@@ -33,4 +33,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.8.7.*")]
-[assembly: AssemblyFileVersion("1.8.7.0")]
+[assembly: AssemblyFileVersion("1.8.7.5")]

--- a/letsencrypt-win-simple/Properties/Settings.Designer.cs
+++ b/letsencrypt-win-simple/Properties/Settings.Designer.cs
@@ -67,5 +67,23 @@ namespace LetsEncrypt.ACME.Simple.Properties {
                 return ((string)(this["CertificatePath"]));
             }
         }
+        
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("60")]
+        public float RenewalDays {
+            get {
+                return ((float)(this["RenewalDays"]));
+            }
+        }
+        
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("WebHosting")]
+        public string CertificateStore {
+            get {
+                return ((string)(this["CertificateStore"]));
+            }
+        }
     }
 }

--- a/letsencrypt-win-simple/Properties/Settings.settings
+++ b/letsencrypt-win-simple/Properties/Settings.settings
@@ -17,5 +17,11 @@
     <Setting Name="CertificatePath" Type="System.String" Scope="Application">
       <Value Profile="(Default)" />
     </Setting>
+    <Setting Name="RenewalDays" Type="System.Single" Scope="Application">
+      <Value Profile="(Default)">60</Value>
+    </Setting>
+    <Setting Name="CertificateStore" Type="System.String" Scope="Application">
+      <Value Profile="(Default)">WebHosting</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/letsencrypt-win-simple/ScheduledRenewal.cs
+++ b/letsencrypt-win-simple/ScheduledRenewal.cs
@@ -12,8 +12,8 @@ namespace LetsEncrypt.ACME.Simple
     {
         public DateTime Date { get; set; }
         public Target Binding { get; set; }
-        public string CentralSSL { get; set; }
-        public string SAN { get; set; }
+        public string CentralSsl { get; set; }
+        public string San { get; set; }
 
         public override string ToString() => $"{Binding} Renew After {Date.ToShortDateString()}";
 

--- a/letsencrypt-win-simple/letsencrypt-win-simple.csproj
+++ b/letsencrypt-win-simple/letsencrypt-win-simple.csproj
@@ -130,6 +130,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ObjectExtensions.cs" />
     <Compile Include="Plugin\IISPlugin.cs" />
     <Compile Include="Plugin\IISSiteServerPlugin.cs" />
     <Compile Include="Plugin\Plugin.cs" />


### PR DESCRIPTION
Added RenewalDays config option
Added CertificateStore config option fixes #98
Fixed some variable names, locations, and protection
Added ObjectExtentions.cs to be able to copy objects so they don't all
get updated.
Changed Manual Plugin sanInput to be able to have a longer input fixes
#102
Fixed Multiple Site SAN Issue where it was trying to update bindings
that were not there.