### PR TITLE
Load IIS version when the IIS plugin is loaded

### DIFF
--- a/letsencrypt-win-simple/Plugin/IISPlugin.cs
+++ b/letsencrypt-win-simple/Plugin/IISPlugin.cs
@@ -14,7 +14,7 @@ namespace LetsEncrypt.ACME.Simple
     {
         public override string Name => "IIS";
 
-        private static Version _iisVersion;
+        private static Version _iisVersion = GetIisVersion();
 
         public override List<Target> GetTargets()
         {
@@ -22,8 +22,7 @@ namespace LetsEncrypt.ACME.Simple
             Log.Information("Scanning IIS Site Bindings for Hosts");
 
             var result = new List<Target>();
-
-            _iisVersion = GetIisVersion();
+            
             if (_iisVersion.Major == 0)
             {
                 Console.WriteLine(" IIS Version not found in windows registry. Skipping scan.");
@@ -114,8 +113,7 @@ namespace LetsEncrypt.ACME.Simple
             Log.Information("Scanning IIS Sites");
 
             var result = new List<Target>();
-
-            _iisVersion = GetIisVersion();
+            
             if (_iisVersion.Major == 0)
             {
                 Console.WriteLine(" IIS Version not found in windows registry. Skipping scan.");
@@ -398,7 +396,7 @@ at " + _sourceFilePath);
             }
         }
 
-        public Version GetIisVersion()
+        private static Version GetIisVersion()
         {
             using (RegistryKey componentsKey = Registry.LocalMachine.OpenSubKey(@"Software\Microsoft\InetStp", false))
             {


### PR DESCRIPTION
When the app is laoded with the --renew option, neither of the `GetTargets()` or `GetSites` method is called, so the _iisVersion is never set, causing a crash when trying to update the website binding.