### PR TITLE
Moving all Renewals to Plugin

### DIFF
--- a/letsencrypt-win-simple/Plugin/IISPlugin.cs
+++ b/letsencrypt-win-simple/Plugin/IISPlugin.cs
@@ -419,9 +419,8 @@ at " + _sourceFilePath);
 
         public override void Renew(Target target)
         {
-            // TODO: make a system where they can execute a program/batch file to update whatever they need after install.
-            // This method with just the Target paramater is currently only used by Centralized SSL
-            Console.WriteLine(" WARNING: Unable to renew.");
+            _iisVersion = GetIisVersion();
+            Program.Auto(target);
         }
 
         public override void DeleteAuthorization(string answerPath, string token, string webRootPath, string filePath)

--- a/letsencrypt-win-simple/Program.cs
+++ b/letsencrypt-win-simple/Program.cs
@@ -869,14 +869,7 @@ namespace LetsEncrypt.ACME.Simple
                         //Not using KeepExisting
                         Options.KeepExisting = false;
                     }
-                    if (renewal.Binding.PluginName == "IIS")
-                    {
-                        Auto(renewal.Binding);
-                    }
-                    else
-                    {
-                        renewal.Binding.Plugin.Renew(renewal.Binding);
-                    }
+                    renewal.Binding.Plugin.Renew(renewal.Binding);
 
                     renewal.Date = DateTime.UtcNow.AddDays(RenewalPeriod);
                     _settings.SaveRenewals(renewals);


### PR DESCRIPTION
Moving IISPlugin Renewal to IISPlugin, it was the last one not using the plugin's renewal method.
Also ensuring that _iisVersion is set for renewal.