### PR TITLE
Manual supress output

### DIFF
--- a/letsencrypt-win-simple/Program.cs
+++ b/letsencrypt-win-simple/Program.cs
@@ -222,18 +222,24 @@ namespace LetsEncrypt.ACME.Simple
                         {
                             foreach (var plugin in Target.Plugins.Values)
                             {
-                                targets.AddRange(plugin.GetTargets());
+                                if (string.IsNullOrEmpty(Options.ManualHost))
+                                {
+                                    targets.AddRange(plugin.GetTargets());
+                                }
                             }
                         }
                         else
                         {
                             foreach (var plugin in Target.Plugins.Values)
                             {
-                                targets.AddRange(plugin.GetSites());
+                                if (string.IsNullOrEmpty(Options.ManualHost))
+                                {
+                                    targets.AddRange(plugin.GetSites());
+                                }
                             }
                         }
 
-                        if (targets.Count == 0)
+                        if (targets.Count == 0 && string.IsNullOrEmpty(Options.ManualHost))
                         {
                             Console.WriteLine("No targets found.");
                             Log.Error("No targets found.");
@@ -315,42 +321,52 @@ namespace LetsEncrypt.ACME.Simple
                         Console.WriteLine();
                         foreach (var plugin in Target.Plugins.Values)
                         {
-                            plugin.PrintMenu();
+                            if (string.IsNullOrEmpty(Options.ManualHost))
+                            {
+                                plugin.PrintMenu();
+                            }
+                            else if (plugin.Name == "Manual")
+                            {
+                                plugin.PrintMenu();
+                            }
                         }
 
-                        Console.WriteLine(" A: Get certificates for all hosts");
-                        Console.WriteLine(" Q: Quit");
-                        Console.Write("Which host do you want to get a certificate for: ");
-                        var response = Console.ReadLine().ToLowerInvariant();
-                        switch (response)
+                        if (string.IsNullOrEmpty(Options.ManualHost))
                         {
-                            case "a":
-                                foreach (var target in targets)
-                                {
-                                    Auto(target);
-                                }
-                                break;
-                            case "q":
-                                return;
-                            default:
-                                var targetId = 0;
-                                if (Int32.TryParse(response, out targetId))
-                                {
-                                    targetId--;
-                                    if (targetId >= 0 && targetId < targets.Count)
+                            Console.WriteLine(" A: Get certificates for all hosts");
+                            Console.WriteLine(" Q: Quit");
+                            Console.Write("Which host do you want to get a certificate for: ");
+                            var response = Console.ReadLine().ToLowerInvariant();
+                            switch (response)
+                            {
+                                case "a":
+                                    foreach (var target in targets)
                                     {
-                                        var binding = targets[targetId];
-                                        Auto(binding);
+                                        Auto(target);
                                     }
-                                }
-                                else
-                                {
-                                    foreach (var plugin in Target.Plugins.Values)
+                                    break;
+                                case "q":
+                                    return;
+                                default:
+                                    var targetId = 0;
+                                    if (Int32.TryParse(response, out targetId))
                                     {
-                                        plugin.HandleMenuResponse(response, targets);
+                                        targetId--;
+                                        if (targetId >= 0 && targetId < targets.Count)
+                                        {
+                                            var binding = targets[targetId];
+                                            Auto(binding);
+                                        }
                                     }
-                                }
-                                break;
+                                    else
+                                    {
+                                        foreach (var plugin in Target.Plugins.Values)
+                                        {
+                                            plugin.HandleMenuResponse(response, targets);
+                                        }
+                                    }
+                                    break;
+                            }
                         }
                     }
                 }

--- a/letsencrypt-win-simple/Properties/AssemblyInfo.cs
+++ b/letsencrypt-win-simple/Properties/AssemblyInfo.cs
@@ -36,4 +36,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 
 [assembly: AssemblyVersion("1.8.8.*")]
-[assembly: AssemblyFileVersion("1.8.8.6")]
+[assembly: AssemblyFileVersion("1.8.8.7")]


### PR DESCRIPTION
Hiding output if running manual
If someone runs it for manual via the command line, don't print out any of the menus from any other plugin.
Working on #135 