### PR TITLE
Fixing multisite SAN + Central SSL Issue

### DIFF
--- a/letsencrypt-win-simple/Plugin/IISPlugin.cs
+++ b/letsencrypt-win-simple/Plugin/IISPlugin.cs
@@ -181,7 +181,7 @@ namespace LetsEncrypt.ACME.Simple
                 }
             }
 
-            return result;
+            return result.OrderBy(r => r.SiteId).ToList();
         }
 
         private readonly string _sourceFilePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "web_config.xml");
@@ -310,7 +310,10 @@ at " + _sourceFilePath);
                     {
                         hosts.Add(target.Host);
                     }
-                    hosts.AddRange(target.AlternativeNames);
+                    if (target.AlternativeNames != null && target.AlternativeNames.Any())
+                    {
+                        hosts.AddRange(target.AlternativeNames);
+                    }
 
                     foreach (var host in hosts)
                     {
@@ -349,7 +352,7 @@ at " + _sourceFilePath);
                             }
                             else
                             {
-                                Console.WriteLine("Not updating binding, see log for details");
+                                Console.WriteLine("You specified Central SSL, have an existing binding, aren't replacing the binding, and the existing binding is using Central SSL with SNI, so there is nothing to update for this binding");
                                 Log.Information(
                                     "You specified Central SSL, have an existing binding, aren't replacing the binding, and the existing binding is using Central SSL with SNI, so there is nothing to update for this binding");
                             }

--- a/letsencrypt-win-simple/Plugin/IISSiteServerPlugin.cs
+++ b/letsencrypt-win-simple/Plugin/IISSiteServerPlugin.cs
@@ -195,6 +195,7 @@ namespace LetsEncrypt.ACME.Simple
             }
             else if (!Program.Options.Renew || !Program.Options.KeepExisting)
             {
+                var pfxFilename = Program.GetCertificate(totalTarget);
                 //If it is using centralized SSL, renewing, and replacing existing it needs to replace the existing binding.
                 Log.Information("Updating new Central SSL Certificate");
                 foreach (var site in runSites)

--- a/letsencrypt-win-simple/Program.cs
+++ b/letsencrypt-win-simple/Program.cs
@@ -282,7 +282,7 @@ namespace LetsEncrypt.ACME.Simple
                                             }
                                             else
                                             {
-                                                Console.WriteLine($" {count}: SAN - {targets[count - 1]}");
+                                                Console.WriteLine($" {targets[count - 1].SiteId}: SAN - {targets[count - 1]}");
                                             }
                                             count++;
                                         }
@@ -307,7 +307,14 @@ namespace LetsEncrypt.ACME.Simple
                             {
                                 foreach (var binding in targets)
                                 {
-                                    Console.WriteLine($" {count}: {binding}");
+                                    if (!Options.San)
+                                    {
+                                        Console.WriteLine($" {count}: {binding}");
+                                    }
+                                    else
+                                    {
+                                        Console.WriteLine($" {binding.SiteId}: SAN - {binding}");
+                                    }
                                     count++;
                                 }
                             }


### PR DESCRIPTION
When running for SAN and Central SSL and doing a multi site SAN cert, it
wouldn't actually generate the cert. Now it does.