### PR TITLE
Added static file handler to the web.config template 

### DIFF
--- a/letsencrypt-win-simple/Plugin/IISPlugin.cs
+++ b/letsencrypt-win-simple/Plugin/IISPlugin.cs
@@ -189,7 +189,7 @@ namespace LetsEncrypt.ACME.Simple
         public override void BeforeAuthorize(Target target, string answerPath, string token)
         {
             var directory = Path.GetDirectoryName(answerPath);
-            var webConfigPath = Path.Combine(directory, "web.config");
+            var webConfigPath = Path.Combine(directory, "../web.config");
 
             Console.WriteLine($" Writing web.config to add extensionless mime type to {webConfigPath}");
             Log.Information("Writing web.config to add extensionless mime type to {webConfigPath}", webConfigPath);

--- a/letsencrypt-win-simple/Web_Config.xml
+++ b/letsencrypt-win-simple/Web_Config.xml
@@ -2,6 +2,10 @@
 
 <configuration>
   <system.webServer>
+    <handlers>
+		<clear />
+		<add name="StaticFile" path="*" verb="HEAD,GET" modules="StaticFileModule,DefaultDocumentModule,DirectoryListingModule" resourceType="Either" requireAccess="Read" />
+	</handlers>
     <staticContent>
       <mimeMap fileExtension="." mimeType="text/json" />
     </staticContent>


### PR DESCRIPTION
In some configurations IIS returns a 404 for the .well-know flies. Moving the web.config into the .well-know folder and mapping the StaticFile solves this.