### PR TITLE
SAN showing sites with no hosts

### DIFF
--- a/letsencrypt-win-simple/Plugin/IISPlugin.cs
+++ b/letsencrypt-win-simple/Plugin/IISPlugin.cs
@@ -150,7 +150,18 @@ namespace LetsEncrypt.ACME.Simple
                                 });
                             }
                         }
-                        if (hosts.Count <= 100)
+                        if (hosts.Count == 0)
+                        {
+                            result.Add(new Target()
+                            {
+                                SiteId = site.Id,
+                                Host = site.Name,
+                                WebRootPath = null,
+                                PluginName = "No HTTP Bindings Found",
+                                AlternativeNames = null
+                            });
+                        }
+                        else if (hosts.Count <= 100)
                         {
                             result.Add(new Target()
                             {


### PR DESCRIPTION
SAN now shows that there are no HTTP bindings for a site if it doesn't
have one, and won't let you run it for a site that doesn't.