### PR TITLE
Fix for removing subdomain certs

### DIFF
--- a/letsencrypt-win-simple/Program.cs
+++ b/letsencrypt-win-simple/Program.cs
@@ -559,7 +559,9 @@ namespace LetsEncrypt.ACME.Simple
 
                 foreach (var cert in col)
                 {
-                    if (cert.FriendlyName != certificate.FriendlyName)
+                    var subjectName = cert.Subject.Split(',');
+
+                    if (cert.FriendlyName != certificate.FriendlyName && subjectName[1] == " CN=" + host)
                     {
                         Console.WriteLine($" Removing Certificate from Store {cert.FriendlyName}");
                         Log.Information("Removing Certificate from Store {@cert}", cert);


### PR DESCRIPTION
When a cert for a subdomain exists, the find by subject name returns it
when it is removing the cert for the parent domain. This should fix
that.