### PR TITLE
Remove TLS 1.0 as it is deprecated

### DIFF
--- a/letsencrypt-win-simple/Program.cs
+++ b/letsencrypt-win-simple/Program.cs
@@ -43,8 +43,7 @@ namespace LetsEncrypt.ACME.Simple
                 .CreateLogger();
             Log.Information("The global logger has been configured");
 
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls | SecurityProtocolType.Tls11 |
-                                                   SecurityProtocolType.Tls12;
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
 
             var commandLineParseResult = Parser.Default.ParseArguments<Options>(args);
             var parsed = commandLineParseResult as Parsed<Options>;


### PR DESCRIPTION
PCI Council release version 3.1 of their Data Security Standard (DSS) has decided that SSL and TLS 1.0 can no longer be used after June 30, 2016.

With 1.0 as insecure as it is with the current attacks I think the application should no longer be enabling it.