### PR TITLE
New commandline function: --wait

### DIFF
--- a/letsencrypt-win-simple/Options.cs
+++ b/letsencrypt-win-simple/Options.cs
@@ -1,4 +1,4 @@
-﻿using CommandLine;
+using CommandLine;
 
 namespace LetsEncrypt.ACME.Simple
 {
@@ -43,5 +43,8 @@ namespace LetsEncrypt.ACME.Simple
 
         [Option(HelpText = "Keep existing HTTPS bindings, and certificates")]
         public bool KeepExisting { get; set; }
+
+        [Option(HelpText = "Wait for user input before requesting challenge(s) from server")]
+        public bool Wait { get; set; }
     }
 }

--- a/letsencrypt-win-simple/Program.cs
+++ b/letsencrypt-win-simple/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -1026,6 +1026,12 @@ namespace LetsEncrypt.ACME.Simple
                 var answerPath = Environment.ExpandEnvironmentVariables(Path.Combine(webRootPath, filePath));
 
                 target.Plugin.CreateAuthorizationFile(answerPath, httpChallenge.FileContent);
+
+                if (Options.Wait)
+                {
+                    Console.WriteLine($"Press Enter to continue . . .");
+                    Console.ReadLine().ToLowerInvariant();
+                }
 
                 target.Plugin.BeforeAuthorize(target, answerPath, httpChallenge.Token);
 


### PR DESCRIPTION
Before requesting that the ACME server verifies the domain, wait for user input
(useful if uploading the files takes more than 2 seconds)