### PR TITLE
avoid issues with handler mappings

### DIFF
--- a/letsencrypt-win-simple/Web_Config.xml
+++ b/letsencrypt-win-simple/Web_Config.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <configuration>
   <system.webServer>
@@ -6,6 +6,10 @@
     <staticContent>
       <mimeMap fileExtension="." mimeType="text/json" />
     </staticContent>
+    <handlers>
+      <clear />
+			<add name="StaticFile" path="*" verb="*" type="" modules="StaticFileModule,DefaultDocumentModule,DirectoryListingModule" scriptProcessor="" resourceType="Either" requireAccess="Read" allowPathInfo="false" preCondition="" responseBufferLimit="4194304" />
+    </handlers>
   </system.webServer>
   <system.web>
     <authorization>


### PR DESCRIPTION
The Static file handler must be set before the ExtensionlessUrlHandler for letsencrypt to work in IIS.
This requires additional manual configuration can cause problems in existing framework such as DNN.
This it is better if we set the preferred order in .well-known\acme-challenge\web.config to avoid all the issues.

In short, this is a very simple change solving an issue which affects around half of the users.