### PR TITLE
Unattended runs for custom Plugins #151

### DIFF
--- a/letsencrypt-win-simple/Options.cs
+++ b/letsencrypt-win-simple/Options.cs
@@ -1,4 +1,5 @@
-﻿using CommandLine;
+﻿using System.Collections.Generic;
+using CommandLine;
 
 namespace LetsEncrypt.ACME.Simple
 {
@@ -43,5 +44,10 @@ namespace LetsEncrypt.ACME.Simple
 
         [Option(HelpText = "Keep existing HTTPS bindings, and certificates")]
         public bool KeepExisting { get; set; }
+
+        [Option(HelpText = "Which plugins to use, seperate by comma")]
+        public string Plugins { get; set; }
+
+        public List<string> PluginsCollection { get; set; } 
     }
 }


### PR DESCRIPTION
I thought I'd kickstart #151 by starting simple:

- if you specify `--plugins myplugin,iis` then those two plugins will run (note that IIS is a built-in plugin)
- Plugins need to accept an empty response if they want to run unattended, for example `if (string.IsNullOrEmpty(response) == false && response != "c".ToLowerInvariant()) return;`
- The plugin itself can then can use a config file or some other way to get some optional values so that it can run without prompting the user for anything

I know all this can be made much nicer and I'm happy to put some effort in if this get accepted and we can discuss some more on what else needs to happen to improve this.