### PR TITLE
Unattended runs for custom Plugins #151

### DIFF
--- a/letsencrypt-win-simple/Options.cs
+++ b/letsencrypt-win-simple/Options.cs
@@ -11,6 +11,9 @@ namespace LetsEncrypt.ACME.Simple
         [Option(HelpText = "Accept the terms of service.")]
         public bool AcceptTos { get; set; }
 
+        [Option(HelpText = "Email address (not public) to use for renewal fail notices - only gets set on first run for each Let's Encrypt server")]
+        public string SignerEmail { get; set; }
+
         [Option(HelpText = "Check for renewals.")]
         public bool Renew { get; set; }
 

--- a/letsencrypt-win-simple/Options.cs
+++ b/letsencrypt-win-simple/Options.cs
@@ -1,4 +1,5 @@
-﻿using CommandLine;
+﻿using System.Collections.Generic;
+using CommandLine;
 
 namespace LetsEncrypt.ACME.Simple
 {
@@ -46,5 +47,10 @@ namespace LetsEncrypt.ACME.Simple
 
         [Option(HelpText = "Warmup sites before authorization")]
         public bool Warmup { get; set; }
+        
+        [Option(HelpText = "Which plugins to use, seperate by comma")]
+        public string Plugins { get; set; }
+
+        public List<string> PluginsCollection { get; set; }
     }
 }

--- a/letsencrypt-win-simple/Options.cs
+++ b/letsencrypt-win-simple/Options.cs
@@ -48,9 +48,7 @@ namespace LetsEncrypt.ACME.Simple
         [Option(HelpText = "Warmup sites before authorization")]
         public bool Warmup { get; set; }
         
-        [Option(HelpText = "Which plugins to use, seperate by comma")]
-        public string Plugins { get; set; }
-
-        public List<string> PluginsCollection { get; set; }
+        [Option(HelpText = "Which plugin to use")]
+        public string Plugin { get; set; }
     }
 }

--- a/letsencrypt-win-simple/Program.cs
+++ b/letsencrypt-win-simple/Program.cs
@@ -224,16 +224,16 @@ namespace LetsEncrypt.ACME.Simple
         private static void HandleMenuResponseForPlugins(List<Target> targets, string command)
         {
             // Only run the plugin specified in the config
-            foreach (var plugin in Target.Plugins.Values)
+            if (!string.IsNullOrWhiteSpace(Options.Plugin))
             {
-                if (!string.IsNullOrWhiteSpace(Options.Plugin) && string.Equals(Options.Plugin, plugin.Name, StringComparison.InvariantCultureIgnoreCase))
-                {
+                var plugin = Target.Plugins.Values.FirstOrDefault(x => string.Equals(x.Name, Options.Plugin, StringComparison.InvariantCultureIgnoreCase));
+                if (plugin != null)
                     plugin.HandleMenuResponse(command, targets);
-                }
-                else
-                {
+            }
+            else
+            {
+                foreach (var plugin in Target.Plugins.Values)
                     plugin.HandleMenuResponse(command, targets);
-                }
             }
         }
 

--- a/letsencrypt-win-simple/Program.cs
+++ b/letsencrypt-win-simple/Program.cs
@@ -89,8 +89,12 @@ namespace LetsEncrypt.ACME.Simple
                             LoadRegistrationFromFile(registrationPath);
                         else
                         {
-                            Console.Write("Enter an email address (not public, used for renewal fail notices): ");
-                            var email = Console.ReadLine().Trim();
+                            string email = Options.SignerEmail;
+                            if (string.IsNullOrWhiteSpace(email))
+                            {
+                                Console.Write("Enter an email address (not public, used for renewal fail notices): ");
+                                email = Console.ReadLine().Trim();
+                            }
 
                             string[] contacts = GetContacts(email);
 
@@ -166,8 +170,11 @@ namespace LetsEncrypt.ACME.Simple
                 Console.ResetColor();
             }
 
-            Console.WriteLine("Press enter to continue.");
-            Console.ReadLine();
+            if (string.IsNullOrWhiteSpace(Options.Plugin))
+            {
+                Console.WriteLine("Press enter to continue.");
+                Console.ReadLine();
+            }
         }
 
         private static bool TryParseOptions(string[] args)

--- a/letsencrypt-win-simple/Program.cs
+++ b/letsencrypt-win-simple/Program.cs
@@ -121,7 +121,7 @@ namespace LetsEncrypt.ACME.Simple
                         Console.WriteLine();
                         PrintMenuForPlugins();
 
-                        if (string.IsNullOrEmpty(Options.ManualHost) && !Options.PluginsCollection.Any())
+                        if (string.IsNullOrEmpty(Options.ManualHost) && string.IsNullOrWhiteSpace(Options.Plugin))
                         {
                             Console.WriteLine(" A: Get certificates for all hosts");
                             Console.WriteLine(" Q: Quit");
@@ -139,7 +139,7 @@ namespace LetsEncrypt.ACME.Simple
                                     break;
                             }
                         }
-                        else if (Options.PluginsCollection.Any())
+                        else if (!string.IsNullOrWhiteSpace(Options.Plugin))
                         {
                             // If there's plugins in the options, go through all 
                             // of them and only do ProcessDefaultCommand for the selected ones
@@ -185,15 +185,6 @@ namespace LetsEncrypt.ACME.Simple
 
                 Options = parsed.Value;
 
-                Options.PluginsCollection = new List<string>();
-                if (!string.IsNullOrWhiteSpace(Options.Plugins))
-                {
-                    foreach (var plugin in Options.Plugins.Split(','))
-                    {
-                        Options.PluginsCollection.Add(plugin.Trim().ToLowerInvariant());
-                    }
-                }
-
                 Log.Debug("{@Options}", Options);
 
                 return true;
@@ -236,7 +227,7 @@ namespace LetsEncrypt.ACME.Simple
             // Only run plugins specified in the config
             foreach (var plugin in Target.Plugins.Values)
             {
-                if (Options.PluginsCollection.Any() && Options.PluginsCollection.Contains(plugin.Name.ToLowerInvariant()))
+                if (!string.IsNullOrWhiteSpace(Options.Plugin) && string.Equals(Options.Plugin, plugin.Name, StringComparison.InvariantCultureIgnoreCase))
                 {
                     plugin.HandleMenuResponse(command, targets);
                 }
@@ -359,7 +350,7 @@ namespace LetsEncrypt.ACME.Simple
             // Check for plugins specified in the options
             // Only print the menus if there's no plugins specified
             // Otherwise: you actually have no choice, the specified ones will run
-            if (Options.PluginsCollection.Any())
+            if (!string.IsNullOrWhiteSpace(Options.Plugin))
                 return;
 
             foreach (var plugin in Target.Plugins.Values)

--- a/letsencrypt-win-simple/Program.cs
+++ b/letsencrypt-win-simple/Program.cs
@@ -236,6 +236,11 @@ namespace LetsEncrypt.ACME.Simple
                 var plugin = Target.Plugins.Values.FirstOrDefault(x => string.Equals(x.Name, Options.Plugin, StringComparison.InvariantCultureIgnoreCase));
                 if (plugin != null)
                     plugin.HandleMenuResponse(command, targets);
+                else
+                {
+                    Console.WriteLine($"Plugin '{Options.Plugin}' could not be found. Press enter to exit.");
+                    Console.ReadLine();
+                }
             }
             else
             {

--- a/letsencrypt-win-simple/Program.cs
+++ b/letsencrypt-win-simple/Program.cs
@@ -141,8 +141,7 @@ namespace LetsEncrypt.ACME.Simple
                         }
                         else if (!string.IsNullOrWhiteSpace(Options.Plugin))
                         {
-                            // If there's plugins in the options, go through all 
-                            // of them and only do ProcessDefaultCommand for the selected ones
+                            // If there's a plugin in the options, only do ProcessDefaultCommand for the selected plugin
                             // Plugins that can run automatically should allow for an empty string as menu response to work
                             ProcessDefaultCommand(targets, string.Empty);
                         }
@@ -224,7 +223,7 @@ namespace LetsEncrypt.ACME.Simple
 
         private static void HandleMenuResponseForPlugins(List<Target> targets, string command)
         {
-            // Only run plugins specified in the config
+            // Only run the plugin specified in the config
             foreach (var plugin in Target.Plugins.Values)
             {
                 if (!string.IsNullOrWhiteSpace(Options.Plugin) && string.Equals(Options.Plugin, plugin.Name, StringComparison.InvariantCultureIgnoreCase))
@@ -347,9 +346,9 @@ namespace LetsEncrypt.ACME.Simple
 
         private static void PrintMenuForPlugins()
         {
-            // Check for plugins specified in the options
-            // Only print the menus if there's no plugins specified
-            // Otherwise: you actually have no choice, the specified ones will run
+            // Check for a plugin specified in the options
+            // Only print the menus if there's no plugin specified
+            // Otherwise: you actually have no choice, the specified plugin will run
             if (!string.IsNullOrWhiteSpace(Options.Plugin))
                 return;
 


### PR DESCRIPTION
I thought I'd kickstart #151 by starting simple:
- if you specify `--plugins myplugin,iis` then those two plugins will run (note that IIS is a built-in plugin)
- Plugins need to accept an empty response if they want to run unattended, for example `if (string.IsNullOrEmpty(response) == false && response != "c".ToLowerInvariant()) return;`
- The plugin itself can then can use a config file or some other way to get some optional values so that it can run without prompting the user for anything

I know all this can be made much nicer and I'm happy to put some effort in if this get accepted and we can discuss some more on what else needs to happen to improve this.
