### PR TITLE
Add option to make the private key non-exportable

### DIFF
--- a/letsencrypt-win-simple/App.config
+++ b/letsencrypt-win-simple/App.config
@@ -44,6 +44,9 @@
       <setting name="CleanupFolders" serializeAs="String">
         <value>True</value>
       </setting>
+      <setting name="PrivateKeyExportable" serializeAs="String">
+        <value>True</value>
+      </setting>
     </LetsEncrypt.ACME.Simple.Properties.Settings>
   </applicationSettings>
   <runtime>

--- a/letsencrypt-win-simple/Program.cs
+++ b/letsencrypt-win-simple/Program.cs
@@ -654,10 +654,17 @@ namespace LetsEncrypt.ACME.Simple
             certificate = null;
             try
             {
+                X509KeyStorageFlags flags = X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.PersistKeySet;
+                if (Properties.Settings.Default.PrivateKeyExportable)
+                {
+                    Console.WriteLine($" Set private key exportable");
+                    Log.Information("Set private key exportable");
+                    flags |= X509KeyStorageFlags.Exportable;
+                }
+
                 // See http://paulstovell.com/blog/x509certificate2
                 certificate = new X509Certificate2(pfxFilename, Properties.Settings.Default.PFXPassword,
-                    X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.PersistKeySet |
-                    X509KeyStorageFlags.Exportable);
+                    flags);
 
                 certificate.FriendlyName =
                     $"{binding.Host} {DateTime.Now.ToString(Properties.Settings.Default.FileDateFormat)}";

--- a/letsencrypt-win-simple/Properties/Settings.Designer.cs
+++ b/letsencrypt-win-simple/Properties/Settings.Designer.cs
@@ -94,5 +94,14 @@ namespace LetsEncrypt.ACME.Simple.Properties {
                 return ((bool)(this["CleanupFolders"]));
             }
         }
+        
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool PrivateKeyExportable {
+            get {
+                return ((bool)(this["PrivateKeyExportable"]));
+            }
+        }
     }
 }

--- a/letsencrypt-win-simple/Properties/Settings.settings
+++ b/letsencrypt-win-simple/Properties/Settings.settings
@@ -28,5 +28,8 @@
     <Setting Name="CleanupFolders" Type="System.Boolean" Scope="Application">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="PrivateKeyExportable" Type="System.Boolean" Scope="Application">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
We have a company policy that the private key should not be exportable. This adds an option to make the key non-exportable.

I kept the behavior as before. By default the key will be exportable, only when the appsetting is set to "False" it will be non-exportable.

It might be preferable to set the default to non-exportable. I can't think of a reason to export a Let's Encrypt-certificate, as you can easily request a new one. 
