### PR TITLE
In response to #297 I've created --San --ManualHost mode support w/ Renewal support.

### DIFF
--- a/letsencrypt-win-simple/Options.cs
+++ b/letsencrypt-win-simple/Options.cs
@@ -46,5 +46,15 @@ namespace LetsEncrypt.ACME.Simple
 
         [Option(HelpText = "Warmup sites before authorization")]
         public bool Warmup { get; set; }
+
+        [Option(HelpText = "Force Certificate Renewal")]
+        public bool ForceRenewal { get; set; }
+
+        [Option(HelpText = "No Task Scheduler")]
+        public bool NoTaskScheduler { get; set; }
+
+        [Option(HelpText = "Close the application when complete")]
+        public bool CloseOnFinish { get; set; }
+
     }
 }

--- a/letsencrypt-win-simple/Plugin/ManualPlugin.cs
+++ b/letsencrypt-win-simple/Plugin/ManualPlugin.cs
@@ -21,7 +21,28 @@ namespace LetsEncrypt.ACME.Simple
         public override List<Target> GetSites()
         {
             var result = new List<Target>();
+            string[] lsDomains = new string[0];
+            Target loTemp = new Target();
+            
+            if (Program.Options.San && !string.IsNullOrEmpty(Program.Options.ManualHost)) {
+                lsDomains = Program.Options.ManualHost.Split(',');
+                if (!(lsDomains == null) && lsDomains.Length <= 100) {
+                    loTemp = new Target() {
+                        Host = lsDomains[0],
+                        WebRootPath = Program.Options.WebRoot,
+                        PluginName = Name,
+                        AlternativeNames = new List<string>(lsDomains)
+                    };
+                    result.Add(loTemp);
+                    loTemp = null;
 
+                } else {
+                    Console.WriteLine(
+                        $" You must specify at least one (but not more than 100) hosts for a SAN certificate. Let's Encrypt currently has a maximum of 100 alternative names per certificate.");
+                    Log.Error(
+                        "You must specify at least one (but not more than 100) hosts for a SAN certificate. Let's Encrypt currently has a maximum of 100 alternative names per certificate.");
+                }
+            }
             return result;
         }
 
@@ -73,26 +94,45 @@ namespace LetsEncrypt.ACME.Simple
             }
         }
 
-        public override void Renew(Target target)
-        {
-            Console.WriteLine(" WARNING: Unable to renew.");
+        public override void Renew(Target target) {
+            string[] lsDomains = new string[0];
+
+            target.Valid = false;
+            if (Program.ManualSanMode) {
+                if (target.WebRootPath == Program.Options.WebRoot) {
+                    lsDomains = Program.Options.ManualHost.Split(',');
+                    if (lsDomains.Length > 0 && lsDomains.Length <= 100) {
+                        //Check that they're the same domains
+                        target.Valid = (target.Host == lsDomains[0] &&
+                            string.Join(",", target.AlternativeNames.ToArray()) == Program.Options.ManualHost);
+                    }
+                }
+
+            } else {
+                //Check the renewal relates to the CLI's host and webroot
+                target.Valid = (target.Host == Program.Options.ManualHost &&
+                                    target.WebRootPath == Program.Options.WebRoot);
+            }
+            if (target.Valid ) {
+                Console.WriteLine($" Processing Manual Certificate Renewal...");
+                this.Auto(target);
+            }
         }
 
-        public override void PrintMenu()
-        {
-            if (!String.IsNullOrEmpty(Program.Options.ManualHost))
-            {
-                var target = new Target()
-                {
-                    Host = Program.Options.ManualHost,
-                    WebRootPath = Program.Options.WebRoot,
-                    PluginName = Name
-                };
-                Auto(target);
-                Environment.Exit(0);
-            }
+        public override void PrintMenu() {
+            if (!Program.Options.San) {
+                if (!String.IsNullOrEmpty(Program.Options.ManualHost)) {
+                    var target = new Target() {
+                        Host = Program.Options.ManualHost,
+                        WebRootPath = Program.Options.WebRoot,
+                        PluginName = Name
+                    };
+                    Auto(target);
+                    Environment.Exit(0);
+                }
 
-            Console.WriteLine(" M: Generate a certificate manually.");
+                Console.WriteLine(" M: Generate a certificate manually.");
+            }
         }
 
         public override void HandleMenuResponse(string response, List<Target> targets)
@@ -113,7 +153,8 @@ namespace LetsEncrypt.ACME.Simple
                     Stream inputStream = Console.OpenStandardInput(BufferSize);
                     Console.SetIn(new StreamReader(inputStream, Console.InputEncoding, false, BufferSize));
 
-                    var sanInput = Console.ReadLine();
+                    // Include host in the list of DNS names passed to LE
+                    var sanInput = hostName + "," + Console.ReadLine();
                     alternativeNames = sanInput.Split(',');
                     sanList = new List<string>(alternativeNames);
                 }

--- a/letsencrypt-win-simple/ScheduledRenewal.cs
+++ b/letsencrypt-win-simple/ScheduledRenewal.cs
@@ -13,6 +13,8 @@ namespace LetsEncrypt.ACME.Simple
         public string Script { get; set; }
         public string ScriptParameters { get; set; }
         public bool Warmup { get; set; }
+        public string ManualHost { get; internal set; }
+        public bool Renew { get; set; } = false;
 
         public override string ToString() => $"{Binding} Renew After {Date.ToShortDateString()}";
 

--- a/letsencrypt-win-simple/Target.cs
+++ b/letsencrypt-win-simple/Target.cs
@@ -8,6 +8,7 @@ namespace LetsEncrypt.ACME.Simple
     public class Target
     {
         public static Dictionary<string, Plugin> Plugins = new Dictionary<string, Plugin>();
+        public Boolean Valid { get; set; } = true;
 
         static Target()
         {


### PR DESCRIPTION
## **Caveat:** I don't have access to a server with IIS installed so I have not been able to test this code against IIS to ensure backwards compatibility.

This is my very first time contributing to a GitHub project so I hope I'm doing this right but please let me know if anything is wrong.

I have modified the app to support requesting a SAN certificate for ManualHost(s). This is accomplished by utilising existing parameters; passing a CSV list of hosts to the manualhost option:
 --san --manualhost mainhost.domain.com,host1.otherdomain.co.uk,host2.whatever.com --webroot <path_to_web_root>

*The first host in the list is used as the subject and is the primary host to whom the certificate is issued.

I have also added code into the "Manual" plug-in to handle renewing "Manual" certificates, including SAN certificates. A renewal is triggered in exactly the same way but with either the --renew or --forcerenewal options:
 --renew --san --manualhost mainhost.domain.com,host1.otherdomain.co.uk,host2.whatever.com --webroot <path_to_web_root>

Finally, to support the way that I want to use the tool I have implemented some additional CLI options. I believe I have coded this in a noninvasive fashion so the application's previous behaviour should remain the default:

**--forcerenewal** Causes the renewal logic to ignore the Date in the registry and renew the certificate.
**--notaskscheduler** Skips the prompt and code for creating/updating the scheduled task.
**--closeonfinish** Prevents the app from waiting for a key press at the end of execution.

I hope this is useful, 

John.
