### PR TITLE
Add setting to config vault location

### DIFF
--- a/letsencrypt-win-simple/App.config
+++ b/letsencrypt-win-simple/App.config
@@ -44,6 +44,9 @@
       <setting name="CleanupFolders" serializeAs="String">
         <value>True</value>
       </setting>
+      <setting name="ConfigPath" serializeAs="String">
+        <value />
+      </setting>
     </LetsEncrypt.ACME.Simple.Properties.Settings>
   </applicationSettings>
   <runtime>

--- a/letsencrypt-win-simple/Program.cs
+++ b/letsencrypt-win-simple/Program.cs
@@ -403,11 +403,26 @@ namespace LetsEncrypt.ACME.Simple
                 _certificatePath = _configPath;
             }
         }
-
+        
         private static void CreateConfigPath()
         {
-            _configPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), ClientName,
-                CleanFileName(BaseUri));
+            var configPath = Properties.Settings.Default.ConfigPath;
+            var basePath = "";
+            if (String.IsNullOrWhiteSpace(configPath)
+                    || String.Equals(configPath, Environment.SpecialFolder.ApplicationData.ToString(), StringComparison.OrdinalIgnoreCase))
+                // ApplicationData (per-user, roaming profile) was the default before ConfigPath was configurable.
+                basePath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            else if (String.Equals(configPath, Environment.SpecialFolder.LocalApplicationData.ToString(), StringComparison.OrdinalIgnoreCase))
+                // Per-user, non roaming profile.
+                basePath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            else if (String.Equals(configPath, Environment.SpecialFolder.CommonApplicationData.ToString(), StringComparison.OrdinalIgnoreCase))
+                // Per machine.
+                basePath = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
+            else
+                // Whatever path the user specifies.
+                basePath = configPath;
+
+            _configPath = Path.Combine(basePath, ClientName, CleanFileName(BaseUri));
             Console.WriteLine("Config Folder: " + _configPath);
             Log.Information("Config Folder: {_configPath}", _configPath);
             Directory.CreateDirectory(_configPath);

--- a/letsencrypt-win-simple/Properties/Settings.Designer.cs
+++ b/letsencrypt-win-simple/Properties/Settings.Designer.cs
@@ -94,5 +94,14 @@ namespace LetsEncrypt.ACME.Simple.Properties {
                 return ((bool)(this["CleanupFolders"]));
             }
         }
+        
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string ConfigPath {
+            get {
+                return ((string)(this["ConfigPath"]));
+            }
+        }
     }
 }

--- a/letsencrypt-win-simple/Properties/Settings.settings
+++ b/letsencrypt-win-simple/Properties/Settings.settings
@@ -1,7 +1,5 @@
 ﻿<?xml version='1.0' encoding='utf-8'?>
-
-<SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)"
-              GeneratedClassNamespace="LetsEncrypt.ACME.Simple.Properties" GeneratedClassName="Settings">
+<SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)" GeneratedClassNamespace="LetsEncrypt.ACME.Simple.Properties" GeneratedClassName="Settings">
   <Profiles />
   <Settings>
     <Setting Name="FileDateFormat" Type="System.String" Scope="Application">
@@ -27,6 +25,9 @@
     </Setting>
     <Setting Name="CleanupFolders" Type="System.Boolean" Scope="Application">
       <Value Profile="(Default)">True</Value>
+    </Setting>
+    <Setting Name="ConfigPath" Type="System.String" Scope="Application">
+      <Value Profile="(Default)" />
     </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
Pull request to allow configuring the config vault location.

Add new app setting to allow the config path used to be configurable to per user roaming profile, per user local profile, per machine profile, or arbitrary path. 

I read #146 and noted the issue with email addresses, and potential security problems. Not sure how 0.8 ACEMESharp "profiles" will impact this.

This is the simplest change I could get away with to move the config out of the user profile to a machine level location (we have a admin user who will run this interactively, and a different user for the scheduled task, config needed to be shared).

Regards
Murray