### PR TITLE
Override %APPDATA% as the default location for storing configuration.

### DIFF
--- a/letsencrypt-win-simple/Options.cs
+++ b/letsencrypt-win-simple/Options.cs
@@ -46,5 +46,8 @@ namespace LetsEncrypt.ACME.Simple
 
         [Option(HelpText = "Warmup sites before authorization")]
         public bool Warmup { get; set; }
+
+        [Option(HelpText = "Overrides %APPDATA% as the default folder for Configuration")]
+        public string ConfigFolder { get; set; }
     }
 }

--- a/letsencrypt-win-simple/Program.cs
+++ b/letsencrypt-win-simple/Program.cs
@@ -406,8 +406,8 @@ namespace LetsEncrypt.ACME.Simple
 
         private static void CreateConfigPath()
         {
-            _configPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), ClientName,
-                CleanFileName(BaseUri));
+            var configFolder = Options.ConfigFolder ?? Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            _configPath = Path.Combine(configFolder, ClientName, CleanFileName(BaseUri));
             Console.WriteLine("Config Folder: " + _configPath);
             Log.Information("Config Folder: {_configPath}", _configPath);
             Directory.CreateDirectory(_configPath);


### PR DESCRIPTION
This commit adds the ability to override %APPDATA% as the container for the configuration folders/files. The setting only overrides %APPDATA% to something else, preserving all subfolders and files - e.g. "letsencrypt-win-simple\httpsacme-v01.api.letsencrypt.org" is created inside the folder set in the ConfigFolder setting instead of inside %APPDATA%.