### PR TITLE
Update method Program.PromptYesNo to consider the case when Input is redirected

### DIFF
--- a/letsencrypt-win-simple/Program.cs
+++ b/letsencrypt-win-simple/Program.cs
@@ -564,10 +564,32 @@ namespace LetsEncrypt.ACME.Simple
         {
             while (true)
             {
-                var response = Console.ReadKey(true);
-                if (response.Key == ConsoleKey.Y)
+                ConsoleKey key;
+                if (Console.IsInputRedirected)
+                {
+                    var ch = Console.Read();
+                    if (ch == 13) continue;
+                    if (ch == 110 || ch == 78)
+                    {
+                        key = ConsoleKey.N;
+                    }
+                    else if (ch == 121 || ch == 89)
+                    {
+                        key = ConsoleKey.Y;
+                    }
+                    else
+                    {
+                        key = ConsoleKey.NoName;
+                    }
+                }
+                else
+                {
+                    ConsoleKeyInfo response = Console.ReadKey(true);
+                    key = response.Key;
+                }
+                if (key == ConsoleKey.Y)
                     return true;
-                if (response.Key == ConsoleKey.N)
+                if (key == ConsoleKey.N)
                     return false;
                 Console.WriteLine("Please press Y or N.");
             }


### PR DESCRIPTION
In the case when the application is run by another application in redirect input mode, method Console.ReadKey throws an exception.
To work this around, the updated code checks for redirected input and if input is being redirected, it uses Console.Read() instead of Console.ReadKey.