### PR TITLE
Mention Application Settings wiki page in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Download the latest release from https://github.com/Lone-Coder/letsencrypt-win-s
 
 Please head to the [Wiki](https://github.com/Lone-Coder/letsencrypt-win-simple/wiki) to learn more.
 
+## Settings
+
+See the [Application Settings](https://github.com/Lone-Coder/letsencrypt-win-simple/wiki/Application-Settings) page on the wiki for settings such as how to change the location where certificates are stored, how they're generated, and how often they are renewed among other settings.
+
 # Support
 
 If you run into trouble please open an issue at https://github.com/Lone-Coder/letsencrypt-win-simple/issues


### PR DESCRIPTION
There are many issues opened because users couldn't find information about settings in the wiki.

This changes the README.md to explicitly mention and link to the Application Settings wiki page. This is an alternative to PR #383 that moves the entire settings page into the readme.