### PR TITLE
Handling authorization failure

### DIFF
--- a/letsencrypt-win-simple/Exceptions.cs
+++ b/letsencrypt-win-simple/Exceptions.cs
@@ -1,0 +1,15 @@
+﻿using ACMESharp;
+using System;
+
+namespace LetsEncrypt.ACME.Simple
+{
+    public class AuthorizationFailedException : Exception
+    {
+        public AuthorizationState authorizationState { get; set; }
+
+        public AuthorizationFailedException(AuthorizationState state)
+        {
+            authorizationState = state;
+        }
+    }
+}

--- a/letsencrypt-win-simple/Program.cs
+++ b/letsencrypt-win-simple/Program.cs
@@ -1235,7 +1235,7 @@ namespace LetsEncrypt.ACME.Simple
 
                         Log.Error("The ACME server was probably unable to reach {answerUri}", answerUri);
 
-                        Console.WriteLine("\nCheck in a browser to see if the answer file is being served correctly.");
+                        Console.WriteLine("\nCheck in a browser to see if the answer file is being served correctly. If it is, also check the DNSSEC configuration.");
 
                         target.Plugin.OnAuthorizeFail(target);
 

--- a/letsencrypt-win-simple/letsencrypt-win-simple.csproj
+++ b/letsencrypt-win-simple/letsencrypt-win-simple.csproj
@@ -151,6 +151,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Exceptions.cs" />
     <Compile Include="ObjectExtensions.cs" />
     <Compile Include="Plugin\WebDavPlugin.cs" />
     <Compile Include="Plugin\IISPlugin.cs" />


### PR DESCRIPTION
This is a fix for issue #408.

Authorization failed is treated as an exception and handled gracefully, to allow for intermittent failures of the renewal process (e.g. DNS issue, application issue, network issue, server issue ...) without causing the program to bump the renewal date up 30 days, putting certificates at risk of expiring. 