### PR TITLE
Support for automatic detection of changed WebRootPath upon renewal

### DIFF
--- a/letsencrypt-win-simple/Program.cs
+++ b/letsencrypt-win-simple/Program.cs
@@ -1021,7 +1021,7 @@ namespace LetsEncrypt.ACME.Simple
         {
             EnsureTaskScheduler();
 
-            var renewals = _settings.LoadRenewals();
+            var renewals = _settings.LoadRenewals(Options.San);
 
             foreach (var existing in from r in renewals.ToArray() where r.Binding.Host == target.Host select r)
             {
@@ -1050,7 +1050,7 @@ namespace LetsEncrypt.ACME.Simple
         {
             Log.Information("Checking Renewals");
 
-            var renewals = _settings.LoadRenewals();
+            var renewals = _settings.LoadRenewals(Options.San);
             if (renewals.Count == 0)
                 Log.Information("No scheduled renewals found.");
 

--- a/letsencrypt-win-simple/ScheduledRenewal.cs
+++ b/letsencrypt-win-simple/ScheduledRenewal.cs
@@ -1,5 +1,6 @@
 ﻿using Newtonsoft.Json;
 using System;
+using System.Linq;
 
 namespace LetsEncrypt.ACME.Simple
 {

--- a/letsencrypt-win-simple/ScheduledRenewal.cs
+++ b/letsencrypt-win-simple/ScheduledRenewal.cs
@@ -1,5 +1,6 @@
 ﻿using Newtonsoft.Json;
 using System;
+using System.IO;
 using System.Linq;
 
 namespace LetsEncrypt.ACME.Simple

--- a/letsencrypt-win-simple/ScheduledRenewal.cs
+++ b/letsencrypt-win-simple/ScheduledRenewal.cs
@@ -23,7 +23,21 @@ namespace LetsEncrypt.ACME.Simple
 
         internal static ScheduledRenewal Load(string renewal)
         {
-            return JsonConvert.DeserializeObject<ScheduledRenewal>(renewal);
+            var result = JsonConvert.DeserializeObject<ScheduledRenewal>(renewal);
+
+			if (result == null || result.Binding == null)
+				return result;
+
+			if (result.Binding.PluginName == "IIS" && !Directory.Exists(result.Binding.WebRootPath)) // Web root path has changed since the initial creation of the certificate, get current path from IIS
+			{
+				var plugin = new IISPlugin();
+				var bindings = san ? plugin.GetSites() : plugin.GetTargets();
+				var matchingBinding = bindings.FirstOrDefault(binding => binding.Host == result.Binding.Host);
+				if (matchingBinding != null)
+					result.Binding.WebRootPath = matchingBinding.WebRootPath;
+			}
+
+			return result;
         }
     }
 }

--- a/letsencrypt-win-simple/ScheduledRenewal.cs
+++ b/letsencrypt-win-simple/ScheduledRenewal.cs
@@ -23,7 +23,7 @@ namespace LetsEncrypt.ACME.Simple
             return JsonConvert.SerializeObject(this);
         }
 
-        internal static ScheduledRenewal Load(string renewal)
+        internal static ScheduledRenewal Load(string renewal, bool san)
         {
             var result = JsonConvert.DeserializeObject<ScheduledRenewal>(renewal);
 

--- a/letsencrypt-win-simple/Settings.cs
+++ b/letsencrypt-win-simple/Settings.cs
@@ -28,7 +28,7 @@ namespace LetsEncrypt.ACME.Simple
 
         const string renewalsValueName = "Renewals";
 
-        public List<ScheduledRenewal> LoadRenewals()
+        public List<ScheduledRenewal> LoadRenewals(bool san)
         {
             var result = new List<ScheduledRenewal>();
             var values = Registry.GetValue(registryKey, renewalsValueName, null) as string[];
@@ -36,7 +36,7 @@ namespace LetsEncrypt.ACME.Simple
             {
                 foreach (var renewal in values)
                 {
-                    result.Add(ScheduledRenewal.Load(renewal));
+                    result.Add(ScheduledRenewal.Load(renewal, san));
                 }
             }
             return result;


### PR DESCRIPTION
I hope I'm doing this right, as it's my first pull request on github.

This change is for detecting changed WebRootPaths when doing a --renew.

Our sites are hosted on IIS and when we upload new versions, we put these in new folders and change the IIS to target a new path. This means letsencrypt can't renew the certificates in its current state, because it relies on a static path.

So I've extended letsencrypt to find the proper path if necessary upon deserializing the scheduled renewals.