### PR TITLE
Bugfixes to enable validation use cases

### DIFF
--- a/letsencrypt-win-simple/Plugin/ManualPlugin.cs
+++ b/letsencrypt-win-simple/Plugin/ManualPlugin.cs
@@ -136,6 +136,18 @@ namespace LetsEncrypt.ACME.Simple
             }
         }
 
+        private readonly string _sourceFilePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "web_config.xml");
+
+
+        public override void BeforeAuthorize(Target target, string answerPath, string token)
+        {
+            var directory = Path.GetDirectoryName(answerPath);
+            var webConfigPath = Path.Combine(directory, "web.config");
+
+            Log.Information("Writing web.config to add extensionless mime type to {webConfigPath}", webConfigPath);
+            File.Copy(_sourceFilePath, webConfigPath, true);
+        }
+
         public override void CreateAuthorizationFile(string answerPath, string fileContents)
         {
             Log.Information("Writing challenge answer to {answerPath}", answerPath);

--- a/letsencrypt-win-simple/Web_Config.xml
+++ b/letsencrypt-win-simple/Web_Config.xml
@@ -2,6 +2,7 @@
 
 <configuration>
   <system.webServer>
+    <httpRedirect enabled="false" />
     <validation validateIntegratedModeConfiguration="false" />
     <staticContent>
       <mimeMap fileExtension="." mimeType="text/json" />


### PR DESCRIPTION
We've got two use cases for validation.

One, when the top level site is redirecting to another site.  We've added an entry in the .well-known web.config to turn off redirection in those folders so that validation can continue.

Also,  we are using this tool to automatically set up ssl certs in our continuous integration environment and found that in Manual mode, the web.config was not being copied to the .well-known subfolder at all.  