### PR TITLE
Add setting for ignoring SSL certificate validatation.

### DIFF
--- a/letsencrypt-win-simple/App.config
+++ b/letsencrypt-win-simple/App.config
@@ -47,6 +47,9 @@
       <setting name="Proxy" serializeAs="String">
         <value />
       </setting>
+      <setting name="IgnoreSSLValidation" serializeAs="String">
+        <value>False</value>
+      </setting>
     </LetsEncrypt.ACME.Simple.Properties.Settings>
   </applicationSettings>
   <runtime>

--- a/letsencrypt-win-simple/Program.cs
+++ b/letsencrypt-win-simple/Program.cs
@@ -39,6 +39,12 @@ namespace LetsEncrypt.ACME.Simple
 
         private static void Main(string[] args)
         {
+            if (Properties.Settings.Default.IgnoreSSLValidation)
+            {
+                System.Net.ServicePointManager.ServerCertificateValidationCallback = delegate { return true; }; // Will allow self-signed certificates and certificates from unknown CAs.
+                System.Net.ServicePointManager.Expect100Continue = false;
+            }
+
             Log = new LogService();
             if (!TryParseOptions(args)) {
                 return;

--- a/letsencrypt-win-simple/Properties/Settings.Designer.cs
+++ b/letsencrypt-win-simple/Properties/Settings.Designer.cs
@@ -121,5 +121,14 @@ namespace LetsEncrypt.ACME.Simple.Properties {
                 return ((string)(this["Proxy"]));
             }
         }
+        
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool IgnoreSSLValidation {
+            get {
+                return ((bool)(this["IgnoreSSLValidation"]));
+            }
+        }
     }
 }

--- a/letsencrypt-win-simple/Properties/Settings.settings
+++ b/letsencrypt-win-simple/Properties/Settings.settings
@@ -35,5 +35,8 @@
     <Setting Name="Proxy" Type="System.String" Scope="Application">
       <Value Profile="(Default)" />
     </Setting>
+    <Setting Name="IgnoreSSLValidation" Type="System.Boolean" Scope="Application">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
Since old versions of Windows (2008) does not recognize the CA used by LetsEncrypt's certificate.