### PR TITLE
Allow task to run in battery mode

### DIFF
--- a/letsencrypt-win-simple/Program.cs
+++ b/letsencrypt-win-simple/Program.cs
@@ -853,6 +853,9 @@ namespace LetsEncrypt.ACME.Simple
                 var runtime = new DateTime(now.Year, now.Month, now.Day, 9, 0, 0);
                 task.Triggers.Add(new DailyTrigger { DaysInterval = 1, StartBoundary = runtime });
                 task.Settings.ExecutionTimeLimit = new TimeSpan(2, 0, 0);
+                task.Settings.DisallowStartIfOnBatteries = false;
+                task.Settings.StopIfGoingOnBatteries = false;
+                task.Settings.StartWhenAvailable = true;
 
                 var currentExec = Assembly.GetExecutingAssembly().Location;
 


### PR DESCRIPTION
- Some USV drivers will run a server in battery mode. Preventing the task
  from ever running.