### PR TITLE
Fix minor spelling mistake (empty choice selection)

### DIFF
--- a/letsencrypt-win-simple/Services/InputService.cs
+++ b/letsencrypt-win-simple/Services/InputService.cs
@@ -249,7 +249,7 @@ namespace LetsEncrypt.ACME.Simple.Services
             CreateSpace();
             if (listItems.Count() == 0)
             {
-                Console.WriteLine($" [emtpy] ");
+                Console.WriteLine($" [empty] ");
                 Console.WriteLine();
                 return;
             }


### PR DESCRIPTION
This fixes a minor spelling mistake when choice selection is empty found when no scheduled renewals present and attempting to delete all :)