### PR TITLE
Update for PowerShell 2.0 compatibility

### DIFF
--- a/letsencrypt-win-simple/Scripts/ImportExchange.ps1
+++ b/letsencrypt-win-simple/Scripts/ImportExchange.ps1
@@ -17,7 +17,7 @@ param(
 Add-PSSnapin Microsoft.Exchange.Management.PowerShell.SnapIn
 
 #$OldThumbprint = (Get-Item -Path RDS:\GatewayServer\SSLCertificate\Thumbprint).CurrentValue
-$CertInStore = Get-ChildItem -Path Cert:\LocalMachine -Recurse | Where-Object thumbprint -eq $NewCertThumbprint | Sort-Object -Descending | Select-Object -f 1
+$CertInStore = Get-ChildItem -Path Cert:\LocalMachine -Recurse | Where-Object {$_.thumbprint -eq $NewCertThumbprint} | Sort-Object -Descending | Select-Object -f 1
 if($CertInStore){
     try{
         # Cert must exist in the personal store of machine to bind to RD Gateway
@@ -28,7 +28,7 @@ if($CertInStore){
             $SourceStore = New-Object  -TypeName System.Security.Cryptography.X509Certificates.X509Store  -ArgumentList $SourceStorename, $SourceStoreScope
             $SourceStore.Open([System.Security.Cryptography.X509Certificates.OpenFlags]::ReadOnly)
             
-            $cert = $SourceStore.Certificates | Where-Object thumbprint -eq $CertInStore.Thumbprint
+            $cert = $SourceStore.Certificates | Where-Object {$_.thumbprint -eq $CertInStore.Thumbprint}
             
             
             
@@ -43,7 +43,7 @@ if($CertInStore){
             $SourceStore.Close()
             $DestStore.Close()
 
-            $CertInStore = Get-ChildItem -Path Cert:\LocalMachine\My -Recurse | Where-Object thumbprint -eq $NewCertThumbprint | Sort-Object -Descending | Select-Object -f 1
+            $CertInStore = Get-ChildItem -Path Cert:\LocalMachine\My -Recurse | Where-Object {$_.thumbprint -eq $NewCertThumbprint} | Sort-Object -Descending | Select-Object -f 1
         }
         Enable-ExchangeCertificate -Services $ExchangeServices -Thumbprint $CertInStore.Thumbprint -ErrorAction Stop
         "Cert thumbprint set to the following exchange services: $ExchangeServices"  

--- a/letsencrypt-win-simple/Scripts/ImportRDGateway.ps1
+++ b/letsencrypt-win-simple/Scripts/ImportRDGateway.ps1
@@ -8,7 +8,7 @@ param(
 Import-Module RemoteDesktopServices
 
 #$OldThumbprint = (Get-Item -Path RDS:\GatewayServer\SSLCertificate\Thumbprint).CurrentValue
-$CertInStore = Get-ChildItem -Path Cert:\LocalMachine -Recurse | Where-Object thumbprint -eq $NewCertThumbprint | Sort-Object -Descending | Select-Object -f 1
+$CertInStore = Get-ChildItem -Path Cert:\LocalMachine -Recurse | Where-Object {$_.thumbprint -eq $NewCertThumbprint} | Sort-Object -Descending | Select-Object -f 1
 if($CertInStore){
     try{
         # Cert must exist in the personal store of machine to bind to RD Gateway
@@ -19,7 +19,7 @@ if($CertInStore){
             $SourceStore = New-Object  -TypeName System.Security.Cryptography.X509Certificates.X509Store  -ArgumentList $SourceStorename, $SourceStoreScope
             $SourceStore.Open([System.Security.Cryptography.X509Certificates.OpenFlags]::ReadOnly)
             
-            $cert = $SourceStore.Certificates | Where-Object thumbprint -eq $CertInStore.Thumbprint
+            $cert = $SourceStore.Certificates | Where-Object {$_.thumbprint -eq $CertInStore.Thumbprint}
             
             
             
@@ -34,7 +34,7 @@ if($CertInStore){
             $SourceStore.Close()
             $DestStore.Close()
 
-            $CertInStore = Get-ChildItem -Path Cert:\LocalMachine\My -Recurse | Where-Object thumbprint -eq $NewCertThumbprint | Sort-Object -Descending | Select-Object -f 1
+            $CertInStore = Get-ChildItem -Path Cert:\LocalMachine\My -Recurse | Where-Object {$_.thumbprint -eq $NewCertThumbprint} | Sort-Object -Descending | Select-Object -f 1
         }
         Set-Item -Path RDS:\GatewayServer\SSLCertificate\Thumbprint -Value $CertInStore.Thumbprint -ErrorAction Stop
         Restart-Service TSGateway -Force -ErrorAction Stop

--- a/letsencrypt-win-simple/Scripts/ImportRDListener.ps1
+++ b/letsencrypt-win-simple/Scripts/ImportRDListener.ps1
@@ -6,7 +6,7 @@ param(
 ## Imports new cert thumbprint into the RDP listener on localhost
 
 #$OldThumbprint = (Get-Item -Path RDS:\GatewayServer\SSLCertificate\Thumbprint).CurrentValue
-$CertInStore = Get-ChildItem -Path Cert:\LocalMachine -Recurse | Where-Object thumbprint -eq $NewCertThumbprint | Sort-Object -Descending | Select-Object -f 1
+$CertInStore = Get-ChildItem -Path Cert:\LocalMachine -Recurse | Where-Object {$_.thumbprint -eq $NewCertThumbprint} | Sort-Object -Descending | Select-Object -f 1
 if($CertInStore){
     try{
         # Cert must exist in the personal store of machine to bind to RD Gateway
@@ -17,7 +17,7 @@ if($CertInStore){
             $SourceStore = New-Object  -TypeName System.Security.Cryptography.X509Certificates.X509Store  -ArgumentList $SourceStorename, $SourceStoreScope
             $SourceStore.Open([System.Security.Cryptography.X509Certificates.OpenFlags]::ReadOnly)
             
-            $cert = $SourceStore.Certificates | Where-Object thumbprint -eq $CertInStore.Thumbprint
+            $cert = $SourceStore.Certificates | Where-Object {$_.thumbprint -eq $CertInStore.Thumbprint}
             
             
             
@@ -32,7 +32,7 @@ if($CertInStore){
             $SourceStore.Close()
             $DestStore.Close()
 
-            $CertInStore = Get-ChildItem -Path Cert:\LocalMachine\My -Recurse | Where-Object thumbprint -eq $NewCertThumbprint | Sort-Object -Descending | Select-Object -f 1
+            $CertInStore = Get-ChildItem -Path Cert:\LocalMachine\My -Recurse | Where-Object {$_.thumbprint -eq $NewCertThumbprint} | Sort-Object -Descending | Select-Object -f 1
         }
         wmic /namespace:\\root\cimv2\TerminalServices PATH Win32_TSGeneralSetting Set SSLCertificateSHA1Hash="$($CertInStore.Thumbprint)"
         # This method might work, but wmi method is more reliable


### PR DESCRIPTION
I have changed the "where-object" syntax to be backwards compatible with PowerShell 2.0, so the scripts can be used on Windows Small Business Server 2011 systems, which are not allowed to update to newer PowerShell versions.