### PR TITLE
Small typo in Azure validation

### DIFF
--- a/letsencrypt-win-simple/Plugins/ValidationPlugins/Dns/Azure.cs
+++ b/letsencrypt-win-simple/Plugins/ValidationPlugins/Dns/Azure.cs
@@ -12,7 +12,7 @@ namespace LetsEncrypt.ACME.Simple.Plugins.ValidationPlugins.Dns
     /// <summary>
     /// Azure DNS validation
     /// </summary>
-    class AzureFactory : BaseValidationPluginFactory<DnsScript>
+    class AzureFactory : BaseValidationPluginFactory<Azure>
     {
         public AzureFactory(ILogService log) : base(log, nameof(Azure), "Azure DNS", AcmeProtocol.CHALLENGE_TYPE_DNS){ }
 


### PR DESCRIPTION
The `AzureFactory` is currently instantiating `DnsScript` instead of `Azure`.